### PR TITLE
Usage of `cds-plugin-ui5` and `cfdestination` on local CF dev

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -5,7 +5,7 @@
     "node": "^18"
   },
   "dependencies": {
-    "@sap/approuter": "^14.3.0"
+    "@sap/approuter": "^14.3.1"
   },
   "scripts": {
     "start": "node node_modules/@sap/approuter/approuter.js",
@@ -16,12 +16,12 @@
   },
   "devDependencies": {
     "@sapui5/types": "^1.117.1",
-    "@typescript-eslint/eslint-plugin": "^6.5.0",
-    "@typescript-eslint/parser": "^6.5.0",
+    "@typescript-eslint/eslint-plugin": "^6.6.0",
+    "@typescript-eslint/parser": "^6.6.0",
     "@ui5/cli": "^3.5.0",
     "@ui5/ts-interface-generator": "^0.8.1",
     "typescript": "^5.2.2",
-    "ui5-middleware-cfdestination": "^3.1.2",
+    "ui5-middleware-cfdestination": "^3.1.3",
     "ui5-middleware-index": "^3.0.1",
     "ui5-middleware-livereload": "^3.0.0",
     "ui5-tooling-transpile": "^3.2.0"

--- a/app/package.json
+++ b/app/package.json
@@ -5,7 +5,7 @@
     "node": "^18"
   },
   "dependencies": {
-    "@sap/approuter": "^14.3.1"
+    "@sap/approuter": "^14.3.2"
   },
   "scripts": {
     "start": "node node_modules/@sap/approuter/approuter.js",
@@ -15,15 +15,15 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@sapui5/types": "^1.117.1",
-    "@typescript-eslint/eslint-plugin": "^6.6.0",
-    "@typescript-eslint/parser": "^6.6.0",
+    "@sapui5/types": "^1.118.0",
+    "@typescript-eslint/eslint-plugin": "^6.7.0",
+    "@typescript-eslint/parser": "^6.7.0",
     "@ui5/cli": "^3.6.0",
     "@ui5/ts-interface-generator": "^0.8.1",
     "typescript": "^5.2.2",
-    "ui5-middleware-cfdestination": "^3.1.4",
+    "ui5-middleware-cfdestination": "^3.2.0",
     "ui5-middleware-index": "^3.0.2",
     "ui5-middleware-livereload": "^3.0.0",
-    "ui5-tooling-transpile": "^3.2.2"
+    "ui5-tooling-transpile": "^3.2.3"
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -18,12 +18,12 @@
     "@sapui5/types": "^1.117.1",
     "@typescript-eslint/eslint-plugin": "^6.6.0",
     "@typescript-eslint/parser": "^6.6.0",
-    "@ui5/cli": "^3.5.0",
+    "@ui5/cli": "^3.6.0",
     "@ui5/ts-interface-generator": "^0.8.1",
     "typescript": "^5.2.2",
-    "ui5-middleware-cfdestination": "^3.1.3",
-    "ui5-middleware-index": "^3.0.1",
+    "ui5-middleware-cfdestination": "^3.1.4",
+    "ui5-middleware-index": "^3.0.2",
     "ui5-middleware-livereload": "^3.0.0",
-    "ui5-tooling-transpile": "^3.2.0"
+    "ui5-tooling-transpile": "^3.2.2"
   }
 }

--- a/app/ui5.yaml
+++ b/app/ui5.yaml
@@ -3,8 +3,8 @@ metadata:
   name: sample.ui5.uaa.ui
 type: application
 
-customConfiguration:
-  mountPath: /
+#customConfiguration:
+#  mountPath: /
 
 framework:
   name: SAPUI5
@@ -29,14 +29,14 @@ server:
     - name: ui5-middleware-cfdestination
       afterMiddleware: ui5-tooling-transpile-middleware
       configuration:
-        debug: false
+        debug: true
         authenticationMethod: route
         appendAuthRoute: true
         allowServices: true
         allowLocalDir: true
         port: 5005
         xsappJson: xs-app.json
-        disableWelcomeFile: true
+        disableWelcomeFile: false
         destinations:
           - name: srv-api
             url: http://localhost:4004

--- a/app/ui5.yaml
+++ b/app/ui5.yaml
@@ -3,6 +3,9 @@ metadata:
   name: sample.ui5.uaa.ui
 type: application
 
+customConfiguration:
+  mountPath: /
+
 framework:
   name: SAPUI5
   version: '1.117.1'

--- a/app/ui5.yaml
+++ b/app/ui5.yaml
@@ -8,7 +8,7 @@ type: application
 
 framework:
   name: SAPUI5
-  version: '1.117.1'
+  version: '1.118.0'
   libraries:
     - name: sap.f
     - name: sap.m

--- a/app/webapp/controller/Home.controller.js
+++ b/app/webapp/controller/Home.controller.js
@@ -32,7 +32,7 @@ sap.ui.define(
           operationMode: 'Server',
           synchronizationMode: 'None',
           groupId: '$direct',
-          serviceUrl: '/ci/',
+          serviceUrl: this.getOwnerComponent().getManifestEntry("/sap.app/dataSources/mainService/uri"),
         })
 
         this._listBinding = oModel.bindList('/User')

--- a/app/webapp/index.html
+++ b/app/webapp/index.html
@@ -8,7 +8,7 @@
     <title>UI5 UAA</title>
     <script
       id="sap-ui-bootstrap"
-      src="https://ui5.sap.com/1.116.0/resources/sap-ui-core.js"
+      src="https://ui5.sap.com/1.117.1/resources/sap-ui-core.js"
       data-sap-ui-language="en"
       data-sap-ui-async="true"
       data-sap-ui-theme="sap_horizon"

--- a/app/webapp/manifest.json
+++ b/app/webapp/manifest.json
@@ -16,7 +16,7 @@
     },
     "dataSources": {
       "mainService": {
-        "uri": "/ci/",
+        "uri": "ci/",
         "type": "OData",
         "settings": {
           "odataVersion": "4.0"

--- a/app/xs-app.json
+++ b/app/xs-app.json
@@ -1,6 +1,9 @@
 {
   "authenticationMethod": "route",
   "welcomeFile": "/webapp/index.html",
+  "login": {
+    "callbackEndpoint": "/login/callback"
+  },
   "logout": {
     "logoutEndpoint": "/do/logout"
   },
@@ -45,12 +48,12 @@
       "authenticationType": "xsuaa"
     },
     {
-      "source": "/ci/(.*)$",
+      "source": "^/ci/(.*)$",
       "authenticationType": "xsuaa",
       "destination": "srv-api"
     },
     {
-      "source": "/v2/ci/(.*)$",
+      "source": "^/v2/ci/(.*)$",
       "authenticationType": "xsuaa",
       "destination": "srv-api"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,16 +36,16 @@
       "name": "sample.ui5.uaa.ui",
       "version": "1.2.1",
       "dependencies": {
-        "@sap/approuter": "^14.3.0"
+        "@sap/approuter": "^14.3.1"
       },
       "devDependencies": {
         "@sapui5/types": "^1.117.1",
-        "@typescript-eslint/eslint-plugin": "^6.5.0",
-        "@typescript-eslint/parser": "^6.5.0",
+        "@typescript-eslint/eslint-plugin": "^6.6.0",
+        "@typescript-eslint/parser": "^6.6.0",
         "@ui5/cli": "^3.5.0",
         "@ui5/ts-interface-generator": "^0.8.1",
         "typescript": "^5.2.2",
-        "ui5-middleware-cfdestination": "^3.1.2",
+        "ui5-middleware-cfdestination": "^3.1.3",
         "ui5-middleware-index": "^3.0.1",
         "ui5-middleware-livereload": "^3.0.0",
         "ui5-tooling-transpile": "^3.2.0"
@@ -2603,9 +2603,9 @@
       }
     },
     "node_modules/@sap/approuter": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/@sap/approuter/-/approuter-14.3.0.tgz",
-      "integrity": "sha512-W2atSrNCaMJU0fT3hKULGkgkdbwaAMugzQy4ggtu1p0drVz4eWEMm6tYfqhAgljwK2qfzWHHIWq/Tj4Blyc1VQ==",
+      "version": "14.3.1",
+      "resolved": "https://registry.npmjs.org/@sap/approuter/-/approuter-14.3.1.tgz",
+      "integrity": "sha512-Ax9U8MmF0guUgzZQrZ16iJZJqmy/e2EhXVQ3+7IS3ol9SXmNk7L60hgh8llxo7yd373VndAxrRWegnjER9a/3w==",
       "dependencies": {
         "@sap/audit-logging": "5.6.3",
         "@sap/e2e-trace": "^3.0.0",
@@ -3552,16 +3552,16 @@
       "integrity": "sha512-txGIh+0eDFzKGC25zORnswy+br1Ha7hj5cMVwKIU7+s0U2AxxJru/jZSMU6OC9MJWP6+pc/hc6ZjyZShpsyY2g=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.5.0.tgz",
-      "integrity": "sha512-2pktILyjvMaScU6iK3925uvGU87E+N9rh372uGZgiMYwafaw9SXq86U04XPq3UH6tzRvNgBsub6x2DacHc33lw==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.6.0.tgz",
+      "integrity": "sha512-CW9YDGTQnNYMIo5lMeuiIG08p4E0cXrXTbcZ2saT/ETE7dWUrNxlijsQeU04qAAKkILiLzdQz+cGFxCJjaZUmA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.5.0",
-        "@typescript-eslint/type-utils": "6.5.0",
-        "@typescript-eslint/utils": "6.5.0",
-        "@typescript-eslint/visitor-keys": "6.5.0",
+        "@typescript-eslint/scope-manager": "6.6.0",
+        "@typescript-eslint/type-utils": "6.6.0",
+        "@typescript-eslint/utils": "6.6.0",
+        "@typescript-eslint/visitor-keys": "6.6.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -3587,15 +3587,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.5.0.tgz",
-      "integrity": "sha512-LMAVtR5GN8nY0G0BadkG0XIe4AcNMeyEy3DyhKGAh9k4pLSMBO7rF29JvDBpZGCmp5Pgz5RLHP6eCpSYZJQDuQ==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.6.0.tgz",
+      "integrity": "sha512-setq5aJgUwtzGrhW177/i+DMLqBaJbdwGj2CPIVFFLE0NCliy5ujIdLHd2D1ysmlmsjdL2GWW+hR85neEfc12w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.5.0",
-        "@typescript-eslint/types": "6.5.0",
-        "@typescript-eslint/typescript-estree": "6.5.0",
-        "@typescript-eslint/visitor-keys": "6.5.0",
+        "@typescript-eslint/scope-manager": "6.6.0",
+        "@typescript-eslint/types": "6.6.0",
+        "@typescript-eslint/typescript-estree": "6.6.0",
+        "@typescript-eslint/visitor-keys": "6.6.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -3615,13 +3615,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.5.0.tgz",
-      "integrity": "sha512-A8hZ7OlxURricpycp5kdPTH3XnjG85UpJS6Fn4VzeoH4T388gQJ/PGP4ole5NfKt4WDVhmLaQ/dBLNDC4Xl/Kw==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.6.0.tgz",
+      "integrity": "sha512-pT08u5W/GT4KjPUmEtc2kSYvrH8x89cVzkA0Sy2aaOUIw6YxOIjA8ilwLr/1fLjOedX1QAuBpG9XggWqIIfERw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.5.0",
-        "@typescript-eslint/visitor-keys": "6.5.0"
+        "@typescript-eslint/types": "6.6.0",
+        "@typescript-eslint/visitor-keys": "6.6.0"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -3632,13 +3632,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.5.0.tgz",
-      "integrity": "sha512-f7OcZOkRivtujIBQ4yrJNIuwyCQO1OjocVqntl9dgSIZAdKqicj3xFDqDOzHDlGCZX990LqhLQXWRnQvsapq8A==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.6.0.tgz",
+      "integrity": "sha512-8m16fwAcEnQc69IpeDyokNO+D5spo0w1jepWWY2Q6y5ZKNuj5EhVQXjtVAeDDqvW6Yg7dhclbsz6rTtOvcwpHg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.5.0",
-        "@typescript-eslint/utils": "6.5.0",
+        "@typescript-eslint/typescript-estree": "6.6.0",
+        "@typescript-eslint/utils": "6.6.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -3659,9 +3659,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.5.0.tgz",
-      "integrity": "sha512-eqLLOEF5/lU8jW3Bw+8auf4lZSbbljHR2saKnYqON12G/WsJrGeeDHWuQePoEf9ro22+JkbPfWQwKEC5WwLQ3w==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.6.0.tgz",
+      "integrity": "sha512-CB6QpJQ6BAHlJXdwUmiaXDBmTqIE2bzGTDLADgvqtHWuhfNP3rAOK7kAgRMAET5rDRr9Utt+qAzRBdu3AhR3sg==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -3672,13 +3672,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.5.0.tgz",
-      "integrity": "sha512-q0rGwSe9e5Kk/XzliB9h2LBc9tmXX25G0833r7kffbl5437FPWb2tbpIV9wAATebC/018pGa9fwPDuvGN+LxWQ==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.6.0.tgz",
+      "integrity": "sha512-hMcTQ6Al8MP2E6JKBAaSxSVw5bDhdmbCEhGW/V8QXkb9oNsFkA4SBuOMYVPxD3jbtQ4R/vSODBsr76R6fP3tbA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.5.0",
-        "@typescript-eslint/visitor-keys": "6.5.0",
+        "@typescript-eslint/types": "6.6.0",
+        "@typescript-eslint/visitor-keys": "6.6.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -3698,47 +3698,18 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.5.0.tgz",
-      "integrity": "sha512-9nqtjkNykFzeVtt9Pj6lyR9WEdd8npPhhIPM992FWVkZuS6tmxHfGVnlUcjpUP2hv8r4w35nT33mlxd+Be1ACQ==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.6.0.tgz",
+      "integrity": "sha512-mPHFoNa2bPIWWglWYdR0QfY9GN0CfvvXX1Sv6DlSTive3jlMTUy+an67//Gysc+0Me9pjitrq0LJp0nGtLgftw==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.5.0",
-        "@typescript-eslint/types": "6.5.0",
-        "@typescript-eslint/typescript-estree": "6.5.0",
+        "@typescript-eslint/scope-manager": "6.6.0",
+        "@typescript-eslint/types": "6.6.0",
+        "@typescript-eslint/typescript-estree": "6.6.0",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -3753,12 +3724,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.5.0.tgz",
-      "integrity": "sha512-yCB/2wkbv3hPsh02ZS8dFQnij9VVQXJMN/gbQsaaY+zxALkZnxa/wagvLEFsAWMPv7d7lxQmNsIzGU1w/T/WyA==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.6.0.tgz",
+      "integrity": "sha512-L61uJT26cMOfFQ+lMZKoJNbAEckLe539VhTxiGHrWl5XSKQgA0RTBZJW2HFPy5T0ZvPVSD93QsrTKDkfNwJGyQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.5.0",
+        "@typescript-eslint/types": "6.6.0",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -10604,6 +10575,37 @@
         "npm": ">= 8"
       }
     },
+    "node_modules/@ui5/fs/node_modules/globby": {
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
+      "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
+      "dev": true,
+      "dependencies": {
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.3.0",
+        "ignore": "^5.2.4",
+        "merge2": "^1.4.1",
+        "slash": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ui5/fs/node_modules/slash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@ui5/logger": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@ui5/logger/-/logger-3.0.0.tgz",
@@ -10676,6 +10678,37 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@ui5/project/node_modules/globby": {
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
+      "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
+      "dev": true,
+      "dependencies": {
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.3.0",
+        "ignore": "^5.2.4",
+        "merge2": "^1.4.1",
+        "slash": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ui5/project/node_modules/slash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@ui5/project/node_modules/xml2js": {
@@ -13410,9 +13443,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
-      "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -13920,19 +13953,20 @@
       }
     },
     "node_modules/globby": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
-      "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
       "dependencies": {
+        "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.3.0",
-        "ignore": "^5.2.4",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
         "merge2": "^1.4.1",
-        "slash": "^4.0.0"
+        "slash": "^3.0.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -17416,15 +17450,12 @@
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
     "node_modules/slash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/smart-buffer": {
@@ -17778,9 +17809,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.1.15",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.15.tgz",
-      "integrity": "sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
+      "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
       "dev": true,
       "dependencies": {
         "chownr": "^2.0.0",
@@ -17840,9 +17871,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.19.3",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.3.tgz",
-      "integrity": "sha512-pQzJ9UJzM0IgmT4FAtYI6+VqFf0lj/to58AV0Xfgg0Up37RyPG7Al+1cepC6/BVuAxR9oNb41/DL4DEoHJvTdg==",
+      "version": "5.19.4",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.4.tgz",
+      "integrity": "sha512-6p1DjHeuluwxDXcuT9VR8p64klWJKo1ILiy19s6C9+0Bh2+NWTX6nD9EPppiER4ICkHDVB1RkVpin/YW2nQn/g==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -18095,9 +18126,9 @@
       "dev": true
     },
     "node_modules/ui5-middleware-cfdestination": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/ui5-middleware-cfdestination/-/ui5-middleware-cfdestination-3.1.2.tgz",
-      "integrity": "sha512-ii+fCMEZVztof8g9coGjcY8Y+eK57f+ygfC7Wp4M2Bs0/+BweoWZs3qK5EDWnskbaP+38ZsJ8b6gTJhNPowSww==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/ui5-middleware-cfdestination/-/ui5-middleware-cfdestination-3.1.3.tgz",
+      "integrity": "sha512-IvyHdBkMXUWXXFgc+qNaaW0EQ1mNp2vj2mMi6Oet42kpsNT6W83QgurVtej9gqXJfRO/px+yl12/1CbrjKRkig==",
       "dev": true,
       "dependencies": {
         "@sap/approuter": "^14.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,22 +11,22 @@
         "app"
       ],
       "dependencies": {
-        "@sap-cloud-sdk/connectivity": "^3.2.0",
-        "@sap-cloud-sdk/http-client": "^3.2.0",
-        "@sap/cds": "^7.0.0",
-        "@sap/cds-odata-v2-adapter-proxy": "^1.7.12",
+        "@sap-cloud-sdk/connectivity": "^3.4.0",
+        "@sap-cloud-sdk/http-client": "^3.4.0",
+        "@sap/cds": "^7.2.0",
+        "@sap/cds-odata-v2-adapter-proxy": "^1.9.21",
         "passport": "^0.6.0"
       },
       "devDependencies": {
-        "@prettier/plugin-xml": "^3.1.1",
+        "@prettier/plugin-xml": "^3.2.0",
         "@sap/eslint-plugin-cds": "^2.6.3",
-        "cds-plugin-ui5": "^0.5.1",
-        "eslint": "^8.23.0",
-        "eslint-config-prettier": "^8.1.0",
-        "eslint-config-standard": "^17.0.0",
+        "cds-plugin-ui5": "^0.5.2",
+        "eslint": "^8.48.0",
+        "eslint-config-prettier": "^9.0.0",
+        "eslint-config-standard": "^17.1.0",
         "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-sonarjs": "^0.19.0",
-        "prettier": "^3.0.0"
+        "eslint-plugin-sonarjs": "^0.21.0",
+        "prettier": "^3.0.3"
       },
       "engines": {
         "node": "^18"
@@ -42,13 +42,13 @@
         "@sapui5/types": "^1.117.1",
         "@typescript-eslint/eslint-plugin": "^6.6.0",
         "@typescript-eslint/parser": "^6.6.0",
-        "@ui5/cli": "^3.5.0",
+        "@ui5/cli": "^3.6.0",
         "@ui5/ts-interface-generator": "^0.8.1",
         "typescript": "^5.2.2",
-        "ui5-middleware-cfdestination": "^3.1.3",
-        "ui5-middleware-index": "^3.0.1",
+        "ui5-middleware-cfdestination": "^3.1.4",
+        "ui5-middleware-index": "^3.0.2",
         "ui5-middleware-livereload": "^3.0.0",
-        "ui5-tooling-transpile": "^3.2.0"
+        "ui5-tooling-transpile": "^3.2.2"
       },
       "engines": {
         "node": "^18"
@@ -176,21 +176,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.11.tgz",
-      "integrity": "sha512-lh7RJrtPdhibbxndr6/xx0w8+CVlY5FJZiaSz908Fpy+G0xkBFTvwLcKJFF4PJxVfGhVWNebikpWGnOoC71juQ==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.15.tgz",
+      "integrity": "sha512-PtZqMmgRrvj8ruoEOIwVA3yoF91O+Hgw9o7DAUTNBA6Mo2jpu31clx9a7Nz/9JznqetTR6zwfC4L3LAjKQXUwA==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.22.10",
-        "@babel/generator": "^7.22.10",
-        "@babel/helper-compilation-targets": "^7.22.10",
-        "@babel/helper-module-transforms": "^7.22.9",
-        "@babel/helpers": "^7.22.11",
-        "@babel/parser": "^7.22.11",
-        "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.11",
-        "@babel/types": "^7.22.11",
+        "@babel/code-frame": "^7.22.13",
+        "@babel/generator": "^7.22.15",
+        "@babel/helper-compilation-targets": "^7.22.15",
+        "@babel/helper-module-transforms": "^7.22.15",
+        "@babel/helpers": "^7.22.15",
+        "@babel/parser": "^7.22.15",
+        "@babel/template": "^7.22.15",
+        "@babel/traverse": "^7.22.15",
+        "@babel/types": "^7.22.15",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -227,12 +227,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.10.tgz",
-      "integrity": "sha512-79KIf7YiWjjdZ81JnLujDRApWtl7BxTqWD88+FFdQEIOG8LJ0etDOM7CXuIgGJa55sGOwZVwuEsaLEm0PJ5/+A==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.15.tgz",
+      "integrity": "sha512-Zu9oWARBqeVOW0dZOjXc3JObrzuqothQ3y/n1kUtrjCoCPLkXUwMvOo/F/TCfoHMbWIFlWwpZtkZVb9ga4U2pA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.22.10",
+        "@babel/types": "^7.22.15",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -254,25 +254,25 @@
       }
     },
     "node_modules/@babel/helper-builder-binary-assignment-operator-visitor": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.22.10.tgz",
-      "integrity": "sha512-Av0qubwDQxC56DoUReVDeLfMEjYYSN1nZrTUrWkXd7hpU73ymRANkbuDm3yni9npkn+RXy9nNbEJZEzXr7xrfQ==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.22.15.tgz",
+      "integrity": "sha512-QkBXwGgaoC2GtGZRoma6kv7Szfv06khvhFav67ZExau2RaXzy8MpHSMO2PNoP2XtmQphJQRHFfg77Bq731Yizw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.22.10"
+        "@babel/types": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.10.tgz",
-      "integrity": "sha512-JMSwHD4J7SLod0idLq5PKgI+6g/hLD/iuWBq08ZX49xE14VpVEojJ5rHWptpirV2j020MvypRLAXAO50igCJ5Q==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
+      "integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
       "dev": true,
       "dependencies": {
         "@babel/compat-data": "^7.22.9",
-        "@babel/helper-validator-option": "^7.22.5",
+        "@babel/helper-validator-option": "^7.22.15",
         "browserslist": "^4.21.9",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -306,15 +306,15 @@
       "dev": true
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.22.11.tgz",
-      "integrity": "sha512-y1grdYL4WzmUDBRGK0pDbIoFd7UZKoDurDzWEoNMYoj1EL+foGRQNyPWDcC+YyegN5y1DUsFFmzjGijB3nSVAQ==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.22.15.tgz",
+      "integrity": "sha512-jKkwA59IXcvSaiK2UN45kKwSC9o+KuoXsBDvHvU/7BecYIp8GQ2UwrVvFgJASUT+hBnwJx6MhvMCuMzwZZ7jlg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
         "@babel/helper-environment-visitor": "^7.22.5",
         "@babel/helper-function-name": "^7.22.5",
-        "@babel/helper-member-expression-to-functions": "^7.22.5",
+        "@babel/helper-member-expression-to-functions": "^7.22.15",
         "@babel/helper-optimise-call-expression": "^7.22.5",
         "@babel/helper-replace-supers": "^7.22.9",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
@@ -338,9 +338,9 @@
       }
     },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
-      "version": "7.22.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.22.9.tgz",
-      "integrity": "sha512-+svjVa/tFwsNSG4NEy1h85+HQ5imbT92Q5/bgtS7P0GTQlP8WuFdqsiABmQouhiFGyV66oGxZFpeYHza1rNsKw==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.22.15.tgz",
+      "integrity": "sha512-29FkPLFjn4TPEa3RE7GpW+qbE8tlsu3jntNYNfcGsc49LphF1PQIiD+vMZ1z1xVOKt+93khA9tc2JBs3kBjA7w==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
@@ -414,40 +414,40 @@
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.22.5.tgz",
-      "integrity": "sha512-aBiH1NKMG0H2cGZqspNvsaBe6wNGjbJjuLy29aU+eDZjSbbN53BaxlpB02xm9v34pLTZ1nIQPFYn2qMZoa5BQQ==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.22.15.tgz",
+      "integrity": "sha512-qLNsZbgrNh0fDQBCPocSL8guki1hcPvltGDv/NxvUoABwFq7GkKSu1nRXeJkVZc+wJvne2E0RKQz+2SQrz6eAA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/types": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.5.tgz",
-      "integrity": "sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
+      "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/types": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.22.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.9.tgz",
-      "integrity": "sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.15.tgz",
+      "integrity": "sha512-l1UiX4UyHSFsYt17iQ3Se5pQQZZHa22zyIXURmvkmLCD4t/aU+dvNWHatKac/D9Vm9UES7nvIqHs4jZqKviUmQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.5",
-        "@babel/helper-module-imports": "^7.22.5",
+        "@babel/helper-module-imports": "^7.22.15",
         "@babel/helper-simple-access": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/helper-validator-identifier": "^7.22.5"
+        "@babel/helper-validator-identifier": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -557,18 +557,18 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
-      "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.15.tgz",
+      "integrity": "sha512-4E/F9IIEi8WR94324mbDUMo074YTheJmd7eZF5vITTeYchqAi6sYXRLHUVsmkdmY4QjfKTcB2jB7dVP3NaBElQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.5.tgz",
-      "integrity": "sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
+      "integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -589,14 +589,14 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.11.tgz",
-      "integrity": "sha512-vyOXC8PBWaGc5h7GMsNx68OH33cypkEDJCHvYVVgVbbxJDROYVtexSk0gK5iCF1xNjRIN2s8ai7hwkWDq5szWg==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.15.tgz",
+      "integrity": "sha512-7pAjK0aSdxOwR+CcYAqgWOGy5dcfvzsTIfFTb2odQqW47MDfv14UaJDY6eng8ylM2EaeKXdxaSWESbkmaQHTmw==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.11",
-        "@babel/types": "^7.22.11"
+        "@babel/template": "^7.22.15",
+        "@babel/traverse": "^7.22.15",
+        "@babel/types": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -688,9 +688,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.14",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.14.tgz",
-      "integrity": "sha512-1KucTHgOvaw/LzCVrEOAyXkr9rQlp0A1HiHRYnSUE9dmb8PvPW7o5sscg+5169r54n3vGlbx6GevTE/Iw/P3AQ==",
+      "version": "7.22.16",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.16.tgz",
+      "integrity": "sha512-+gPfKv8UWeKKeJTUxe59+OobVcrYHETCsORl61EmSkmgymguYk/X5bp7GuUIXaFsc6y++v8ZxPsLSSuujqDphA==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -700,9 +700,9 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.22.5.tgz",
-      "integrity": "sha512-NP1M5Rf+u2Gw9qfSO4ihjcTGW5zXTi36ITLd4/EoAcEhIZ0yjMqmftDNl3QC19CX7olhrjpyU454g/2W7X0jvQ==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.22.15.tgz",
+      "integrity": "sha512-FB9iYlz7rURmRJyXRKEnalYPPdn87H5no108cyuQQyMwlpJ2SJtpIUBI27kdTin956pz+LPypkPVPUTlxOmrsg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -715,14 +715,14 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.22.5.tgz",
-      "integrity": "sha512-31Bb65aZaUwqCbWMnZPduIZxCBngHFlzyN6Dq6KAJjtx+lx6ohKHubc61OomYi7XwVD4Ol0XCVz4h+pYFR048g==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.22.15.tgz",
+      "integrity": "sha512-Hyph9LseGvAeeXzikV88bczhsrLrIZqDPxO+sSmAunMPaGrBGhfMWzCPYTtiW9t+HzSE2wtV8e5cc5P6r1xMDQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
-        "@babel/plugin-transform-optional-chaining": "^7.22.5"
+        "@babel/plugin-transform-optional-chaining": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1024,9 +1024,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-async-generator-functions": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.22.11.tgz",
-      "integrity": "sha512-0pAlmeRJn6wU84zzZsEOx1JV1Jf8fqO9ok7wofIJwUnplYo247dcd24P+cMJht7ts9xkzdtB0EPHmOb7F+KzXw==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.22.15.tgz",
+      "integrity": "sha512-jBm1Es25Y+tVoTi5rfd5t1KLmL8ogLKpXszboWOTTtGFGz2RKnQe2yn7HbZ+kb/B8N0FVSGQo874NSlOU1T4+w==",
       "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.5",
@@ -1074,9 +1074,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.22.10.tgz",
-      "integrity": "sha512-1+kVpGAOOI1Albt6Vse7c8pHzcZQdQKW+wJH+g8mCaszOdDVwRXa/slHPqIw+oJAJANTKDMuM2cBdV0Dg618Vg==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.22.15.tgz",
+      "integrity": "sha512-G1czpdJBZCtngoK1sJgloLiOHUnkb/bLZwqVZD8kXmq0ZnVfTTWUcs9OWtp0mBtYJ+4LQY1fllqBkOIPhXmFmw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -1122,18 +1122,18 @@
       }
     },
     "node_modules/@babel/plugin-transform-classes": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.22.6.tgz",
-      "integrity": "sha512-58EgM6nuPNG6Py4Z3zSuu0xWu2VfodiMi72Jt5Kj2FECmaYk1RrTXA45z6KBFsu9tRgwQDwIiY4FXTt+YsSFAQ==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.22.15.tgz",
+      "integrity": "sha512-VbbC3PGjBdE0wAWDdHM9G8Gm977pnYI0XpqMd6LrKISj8/DJXEsWqgRuTYaNE9Bv0JGhTZUzHDlMk18IpOuoqw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
-        "@babel/helper-compilation-targets": "^7.22.6",
+        "@babel/helper-compilation-targets": "^7.22.15",
         "@babel/helper-environment-visitor": "^7.22.5",
         "@babel/helper-function-name": "^7.22.5",
         "@babel/helper-optimise-call-expression": "^7.22.5",
         "@babel/helper-plugin-utils": "^7.22.5",
-        "@babel/helper-replace-supers": "^7.22.5",
+        "@babel/helper-replace-supers": "^7.22.9",
         "@babel/helper-split-export-declaration": "^7.22.6",
         "globals": "^11.1.0"
       },
@@ -1170,9 +1170,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-destructuring": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.22.10.tgz",
-      "integrity": "sha512-dPJrL0VOyxqLM9sritNbMSGx/teueHF/htMKrPT7DNxccXxRDPYqlgPFFdr8u+F+qUZOkZoXue/6rL5O5GduEw==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.22.15.tgz",
+      "integrity": "sha512-HzG8sFl1ZVGTme74Nw+X01XsUTqERVQ6/RLHo3XjGRzm7XD6QTtfS3NJotVgCGy8BzkDqRjRBD8dAyJn5TuvSQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -1264,9 +1264,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-for-of": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.22.5.tgz",
-      "integrity": "sha512-3kxQjX1dU9uudwSshyLeEipvrLjBCVthCgeTp6CzE/9JYrlAIaeekVxRpCWsDDfYTfRZRoCeZatCQvwo+wvK8A==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.22.15.tgz",
+      "integrity": "sha512-me6VGeHsx30+xh9fbDLLPi0J1HzmeIIyenoOQHuw2D4m2SAU3NrspX5XxJLBpqn5yrLzrlw2Iy3RA//Bx27iOA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -1374,12 +1374,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.22.11.tgz",
-      "integrity": "sha512-o2+bg7GDS60cJMgz9jWqRUsWkMzLCxp+jFDeDUT5sjRlAxcJWZ2ylNdI7QQ2+CH5hWu7OnN+Cv3htt7AkSf96g==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.22.15.tgz",
+      "integrity": "sha512-jWL4eh90w0HQOTKP2MoXXUpVxilxsB2Vl4ji69rSjS3EcZ/v4sBmn+A3NpepuJzBhOaEBbR7udonlHHn5DWidg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.22.9",
+        "@babel/helper-module-transforms": "^7.22.15",
         "@babel/helper-plugin-utils": "^7.22.5",
         "@babel/helper-simple-access": "^7.22.5"
       },
@@ -1488,16 +1488,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-object-rest-spread": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.22.11.tgz",
-      "integrity": "sha512-nX8cPFa6+UmbepISvlf5jhQyaC7ASs/7UxHmMkuJ/k5xSHvDPPaibMo+v3TXwU/Pjqhep/nFNpd3zn4YR59pnw==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.22.15.tgz",
+      "integrity": "sha512-fEB+I1+gAmfAyxZcX1+ZUwLeAuuf8VIg67CTznZE0MqVFumWkh8xWtn58I4dxdVf080wn7gzWoF8vndOViJe9Q==",
       "dev": true,
       "dependencies": {
         "@babel/compat-data": "^7.22.9",
-        "@babel/helper-compilation-targets": "^7.22.10",
+        "@babel/helper-compilation-targets": "^7.22.15",
         "@babel/helper-plugin-utils": "^7.22.5",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-        "@babel/plugin-transform-parameters": "^7.22.5"
+        "@babel/plugin-transform-parameters": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1539,9 +1539,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-optional-chaining": {
-      "version": "7.22.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.22.12.tgz",
-      "integrity": "sha512-7XXCVqZtyFWqjDsYDY4T45w4mlx1rf7aOgkc/Ww76xkgBiOlmjPkx36PBLHa1k1rwWvVgYMPsbuVnIamx2ZQJw==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.22.15.tgz",
+      "integrity": "sha512-ngQ2tBhq5vvSJw2Q2Z9i7ealNkpDMU0rGWnHPKqRZO0tzZ5tlaoz4hDvhXioOoaE0X2vfNss1djwg0DXlfu30A==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -1556,9 +1556,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-parameters": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.22.5.tgz",
-      "integrity": "sha512-AVkFUBurORBREOmHRKo06FjHYgjrabpdqRSwq6+C7R5iTCZOsM4QbcB27St0a4U6fffyAOqh3s/qEfybAhfivg==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.22.15.tgz",
+      "integrity": "sha512-hjk7qKIqhyzhhUvRT683TYQOFa/4cQKwQy7ALvTpODswN40MljzNDa0YldevS6tGbxwaEKVn502JmY0dP7qEtQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -1727,13 +1727,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.22.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.22.9.tgz",
-      "integrity": "sha512-BnVR1CpKiuD0iobHPaM1iLvcwPYN2uVFAqoLVSpEDKWuOikoCv5HbKLxclhKYUXlWkX86DoZGtqI4XhbOsyrMg==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.22.15.tgz",
+      "integrity": "sha512-1uirS0TnijxvQLnlv5wQBwOX3E1wCFX7ITv+9pBV2wKEk4K+M5tqDaoNXnTH8tjEIYHLO98MwiTWO04Ggz4XuA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
-        "@babel/helper-create-class-features-plugin": "^7.22.9",
+        "@babel/helper-create-class-features-plugin": "^7.22.15",
         "@babel/helper-plugin-utils": "^7.22.5",
         "@babel/plugin-syntax-typescript": "^7.22.5"
       },
@@ -1808,17 +1808,17 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.22.14",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.22.14.tgz",
-      "integrity": "sha512-daodMIoVo+ol/g+//c/AH+szBkFj4STQUikvBijRGL72Ph+w+AMTSh55DUETe8KJlPlDT1k/mp7NBfOuiWmoig==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.22.15.tgz",
+      "integrity": "sha512-tZFHr54GBkHk6hQuVA8w4Fmq+MSPsfvMG0vPnOYyTnJpyfMqybL8/MbNCPRT9zc2KBO2pe4tq15g6Uno4Jpoag==",
       "dev": true,
       "dependencies": {
         "@babel/compat-data": "^7.22.9",
-        "@babel/helper-compilation-targets": "^7.22.10",
+        "@babel/helper-compilation-targets": "^7.22.15",
         "@babel/helper-plugin-utils": "^7.22.5",
-        "@babel/helper-validator-option": "^7.22.5",
-        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.22.5",
-        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.22.5",
+        "@babel/helper-validator-option": "^7.22.15",
+        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.22.15",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.22.15",
         "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
         "@babel/plugin-syntax-async-generators": "^7.8.4",
         "@babel/plugin-syntax-class-properties": "^7.12.13",
@@ -1839,39 +1839,39 @@
         "@babel/plugin-syntax-top-level-await": "^7.14.5",
         "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
         "@babel/plugin-transform-arrow-functions": "^7.22.5",
-        "@babel/plugin-transform-async-generator-functions": "^7.22.11",
+        "@babel/plugin-transform-async-generator-functions": "^7.22.15",
         "@babel/plugin-transform-async-to-generator": "^7.22.5",
         "@babel/plugin-transform-block-scoped-functions": "^7.22.5",
-        "@babel/plugin-transform-block-scoping": "^7.22.10",
+        "@babel/plugin-transform-block-scoping": "^7.22.15",
         "@babel/plugin-transform-class-properties": "^7.22.5",
         "@babel/plugin-transform-class-static-block": "^7.22.11",
-        "@babel/plugin-transform-classes": "^7.22.6",
+        "@babel/plugin-transform-classes": "^7.22.15",
         "@babel/plugin-transform-computed-properties": "^7.22.5",
-        "@babel/plugin-transform-destructuring": "^7.22.10",
+        "@babel/plugin-transform-destructuring": "^7.22.15",
         "@babel/plugin-transform-dotall-regex": "^7.22.5",
         "@babel/plugin-transform-duplicate-keys": "^7.22.5",
         "@babel/plugin-transform-dynamic-import": "^7.22.11",
         "@babel/plugin-transform-exponentiation-operator": "^7.22.5",
         "@babel/plugin-transform-export-namespace-from": "^7.22.11",
-        "@babel/plugin-transform-for-of": "^7.22.5",
+        "@babel/plugin-transform-for-of": "^7.22.15",
         "@babel/plugin-transform-function-name": "^7.22.5",
         "@babel/plugin-transform-json-strings": "^7.22.11",
         "@babel/plugin-transform-literals": "^7.22.5",
         "@babel/plugin-transform-logical-assignment-operators": "^7.22.11",
         "@babel/plugin-transform-member-expression-literals": "^7.22.5",
         "@babel/plugin-transform-modules-amd": "^7.22.5",
-        "@babel/plugin-transform-modules-commonjs": "^7.22.11",
+        "@babel/plugin-transform-modules-commonjs": "^7.22.15",
         "@babel/plugin-transform-modules-systemjs": "^7.22.11",
         "@babel/plugin-transform-modules-umd": "^7.22.5",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.22.5",
         "@babel/plugin-transform-new-target": "^7.22.5",
         "@babel/plugin-transform-nullish-coalescing-operator": "^7.22.11",
         "@babel/plugin-transform-numeric-separator": "^7.22.11",
-        "@babel/plugin-transform-object-rest-spread": "^7.22.11",
+        "@babel/plugin-transform-object-rest-spread": "^7.22.15",
         "@babel/plugin-transform-object-super": "^7.22.5",
         "@babel/plugin-transform-optional-catch-binding": "^7.22.11",
-        "@babel/plugin-transform-optional-chaining": "^7.22.12",
-        "@babel/plugin-transform-parameters": "^7.22.5",
+        "@babel/plugin-transform-optional-chaining": "^7.22.15",
+        "@babel/plugin-transform-parameters": "^7.22.15",
         "@babel/plugin-transform-private-methods": "^7.22.5",
         "@babel/plugin-transform-private-property-in-object": "^7.22.11",
         "@babel/plugin-transform-property-literals": "^7.22.5",
@@ -1887,7 +1887,7 @@
         "@babel/plugin-transform-unicode-regex": "^7.22.5",
         "@babel/plugin-transform-unicode-sets-regex": "^7.22.5",
         "@babel/preset-modules": "0.1.6-no-external-plugins",
-        "@babel/types": "^7.22.11",
+        "@babel/types": "^7.22.15",
         "babel-plugin-polyfill-corejs2": "^0.4.5",
         "babel-plugin-polyfill-corejs3": "^0.8.3",
         "babel-plugin-polyfill-regenerator": "^0.5.2",
@@ -1925,16 +1925,16 @@
       }
     },
     "node_modules/@babel/preset-typescript": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.22.5.tgz",
-      "integrity": "sha512-YbPaal9LxztSGhmndR46FmAbkJ/1fAsw293tSU+I5E5h+cnJ3d4GTwyUgGYmOXJYdGA+uNePle4qbaRzj2NISQ==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.22.15.tgz",
+      "integrity": "sha512-HblhNmh6yM+cU4VwbBRpxFhxsTdfS1zsvH9W+gEjD0ARV9+8B4sNfpI6GuhePti84nuvhiwKS539jKPFHskA9A==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5",
-        "@babel/helper-validator-option": "^7.22.5",
+        "@babel/helper-validator-option": "^7.22.15",
         "@babel/plugin-syntax-jsx": "^7.22.5",
-        "@babel/plugin-transform-modules-commonjs": "^7.22.5",
-        "@babel/plugin-transform-typescript": "^7.22.5"
+        "@babel/plugin-transform-modules-commonjs": "^7.22.15",
+        "@babel/plugin-transform-typescript": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1950,9 +1950,9 @@
       "dev": true
     },
     "node_modules/@babel/runtime": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.11.tgz",
-      "integrity": "sha512-ee7jVNlWN09+KftVOu9n7S8gQzD/Z6hN/I8VBRXW4P1+Xe7kJGXMwu8vds4aGIMHZnNbdpSWCfZZtinytpcAvA==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.15.tgz",
+      "integrity": "sha512-T0O+aa+4w0u06iNmapipJXMV4HoUir03hpx3/YqXXhu9xim3w+dVphjFWl1OH8NbZHw5Lbm9k45drDkgq2VNNA==",
       "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -1962,33 +1962,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.5.tgz",
-      "integrity": "sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.22.5",
-        "@babel/parser": "^7.22.5",
-        "@babel/types": "^7.22.5"
+        "@babel/code-frame": "^7.22.13",
+        "@babel/parser": "^7.22.15",
+        "@babel/types": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.11.tgz",
-      "integrity": "sha512-mzAenteTfomcB7mfPtyi+4oe5BZ6MXxWcn4CX+h4IRJ+OOGXBrWU6jDQavkQI9Vuc5P+donFabBfFCcmWka9lQ==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.15.tgz",
+      "integrity": "sha512-DdHPwvJY0sEeN4xJU5uRLmZjgMMDIvMPniLuYzUVXj/GGzysPl0/fwt44JBkyUIzGJPV8QgHMcQdQ34XFuKTYQ==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.22.10",
-        "@babel/generator": "^7.22.10",
+        "@babel/code-frame": "^7.22.13",
+        "@babel/generator": "^7.22.15",
         "@babel/helper-environment-visitor": "^7.22.5",
         "@babel/helper-function-name": "^7.22.5",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.22.11",
-        "@babel/types": "^7.22.11",
+        "@babel/parser": "^7.22.15",
+        "@babel/types": "^7.22.15",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -2006,13 +2006,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.11.tgz",
-      "integrity": "sha512-siazHiGuZRz9aB9NpHy9GOs9xiQPKnMzgdr493iI1M67vRXpnEq8ZOOKzezC5q7zwuQ6sDhdSp4SD9ixKSqKZg==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.15.tgz",
+      "integrity": "sha512-X+NLXr0N8XXmN5ZsaQdm9U2SSC3UbIYq/doL++sueHOTisgZHoKaQtZxGuV2cUPQHMfjKEfg/g6oy7Hm6SKFtA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.15",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -2053,18 +2053,18 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
-      "integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.0.tgz",
+      "integrity": "sha512-JylOEEzDiOryeUnFbQz+oViCXS0KsvR1mvHkoMiu5+UiBvy+RYX7tzlIIIEstF/gVa2tj9AQXk3dgnxv6KxhFg==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.0.tgz",
-      "integrity": "sha512-Lj7DECXqIVCqnqjjHMPna4vn6GJcMgul/wuS0je9OZ9gsL0zzDpKPVtcG1HaDVc+9y+qgXneTeUMbCqXJNpH1A==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
+      "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -2107,18 +2107,18 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.44.0.tgz",
-      "integrity": "sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==",
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.48.0.tgz",
+      "integrity": "sha512-ZSjtmelB7IJfWD2Fvb7+Z+ChTIKWq6kjda95fLcQKNS5aheVHn4IkfgRQE3sIIzTcSLwLcLZUD9UBt+V7+h+Pw==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
-      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.11.tgz",
+      "integrity": "sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -2252,9 +2252,9 @@
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
@@ -2286,20 +2286,14 @@
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.18",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
-      "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
+      "integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/resolve-uri": "3.1.0",
-        "@jridgewell/sourcemap-codec": "1.4.14"
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "node_modules/@jridgewell/trace-mapping/node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "dev": true
     },
     "node_modules/@jsdoc/salty": {
       "version": "0.2.5",
@@ -2540,9 +2534,9 @@
       }
     },
     "node_modules/@prettier/plugin-xml": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@prettier/plugin-xml/-/plugin-xml-3.1.1.tgz",
-      "integrity": "sha512-kf20whg987pD/GWz0s1H2iA2170NnyP7chfmSkY55Dhs8wZwWxVxPItfWsfJo1FVMvTuNUPZY/hTqqHrzxb6Pg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@prettier/plugin-xml/-/plugin-xml-3.2.0.tgz",
+      "integrity": "sha512-1SgnoMIOLjGcKqstr6gmly7J6VoVSXULz0kMDimBE36yj59GrNvaOBPjoeYUmcpU3/IwLiCIJRaCX8qiVSvy/A==",
       "dev": true,
       "dependencies": {
         "@xml-tools/parser": "^1.0.11"
@@ -2552,53 +2546,53 @@
       }
     },
     "node_modules/@sap-cloud-sdk/connectivity": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@sap-cloud-sdk/connectivity/-/connectivity-3.2.0.tgz",
-      "integrity": "sha512-7yZcxdAD3UZ6yXNtvJsTn2Lt8ALmg4ehbkC+pD0VHKtwZZOaTb97OpKycORehUBgW4IUig4FJ/VVbFuKyd8FYw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@sap-cloud-sdk/connectivity/-/connectivity-3.4.0.tgz",
+      "integrity": "sha512-h0fSN1MNcAcU4QaIo8zELDs/45WGMXL2NCBPA+W6aiD0B/czBJhlQ+/WZXTUygE/CzzSzAn0iocoUaK0blB03w==",
       "dependencies": {
-        "@sap-cloud-sdk/resilience": "^3.2.0",
-        "@sap-cloud-sdk/util": "^3.2.0",
+        "@sap-cloud-sdk/resilience": "^3.4.0",
+        "@sap-cloud-sdk/util": "^3.4.0",
         "@sap/xsenv": "^3.4.0",
         "@sap/xssec": "^3.2.17",
         "async-retry": "^1.3.3",
         "axios": "^1.4.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "jsonwebtoken": "^9.0.0"
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "jsonwebtoken": "^9.0.1"
       }
     },
     "node_modules/@sap-cloud-sdk/http-client": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@sap-cloud-sdk/http-client/-/http-client-3.2.0.tgz",
-      "integrity": "sha512-QTohfPnYFpfFm/tt4YxTqAjMcWYcL8h1SbNtVT3eewzTXSNWtQYsDKUPKlf4OsHu82fV2Mb2GWb7spp2a1qotQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@sap-cloud-sdk/http-client/-/http-client-3.4.0.tgz",
+      "integrity": "sha512-7sNi8OtXp8oeTbP+/9Gn+l3k/2teLFVGukfICDpn0L89DxCNuh7W4ogwJNkWPUl/nFope+fuzpdgnCiMJBRo4Q==",
       "dependencies": {
-        "@sap-cloud-sdk/connectivity": "^3.2.0",
-        "@sap-cloud-sdk/resilience": "^3.2.0",
-        "@sap-cloud-sdk/util": "^3.2.0",
+        "@sap-cloud-sdk/connectivity": "^3.4.0",
+        "@sap-cloud-sdk/resilience": "^3.4.0",
+        "@sap-cloud-sdk/util": "^3.4.0",
         "axios": "^1.4.0"
       }
     },
     "node_modules/@sap-cloud-sdk/resilience": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@sap-cloud-sdk/resilience/-/resilience-3.2.0.tgz",
-      "integrity": "sha512-+Tpa8KPyvwG86nxrM+VoWruihsBmsWT9Ijs/ru+aNT4USZAQ6Zw+B87ouReWAqJlbMXFD2X6U2+BxaTGzBxDJw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@sap-cloud-sdk/resilience/-/resilience-3.4.0.tgz",
+      "integrity": "sha512-ZT9gKJ9GQOOeplTNU4Z4UyRk1wGXFAdVNbv8HtHuMO5eGzqZahnPq7BP42puzsZDrPKccKxJYS9xeSaw9cbTdg==",
       "dependencies": {
-        "@sap-cloud-sdk/util": "^3.2.0",
+        "@sap-cloud-sdk/util": "^3.4.0",
         "async-retry": "^1.3.3",
         "axios": "^1.4.0",
-        "opossum": "^7.1.0"
+        "opossum": "^8.0.1"
       }
     },
     "node_modules/@sap-cloud-sdk/util": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@sap-cloud-sdk/util/-/util-3.2.0.tgz",
-      "integrity": "sha512-oDx7w5FZeShQq3hjTLFiyIPk63odOR5Uke3Lv7Y1uW526xGCVhnMqNPv5CTnRbyKY5JE4Z7o0RMk/jlcCBukJQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@sap-cloud-sdk/util/-/util-3.4.0.tgz",
+      "integrity": "sha512-9t91cJ1rdt7A7cbaizw62sJ1ImD9SviGNtQ5L51tcT5dTkFVdDFs63me1het0XAo7xdtfXO+VwkW3A4RojGrZw==",
       "dependencies": {
         "axios": "^1.4.0",
         "chalk": "^4.1.0",
         "logform": "^2.5.1",
-        "voca": "^1.4.0",
-        "winston": "^3.8.2",
+        "voca": "^1.4.1",
+        "winston": "^3.10.0",
         "winston-transport": "^4.5.0"
       }
     },
@@ -2661,12 +2655,58 @@
         "node": "^16.0.0 || ^18.0.0"
       }
     },
+    "node_modules/@sap/approuter/node_modules/@sap/xssec": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@sap/xssec/-/xssec-3.3.0.tgz",
+      "integrity": "sha512-WCmalrfAjpqb3HOclWVwrwm6TSFZVO6l/nrnQ4ADR/xTeXkUz40PokHWqa5XDuCi6aL/xOFAk6+VVnIhGA15Lw==",
+      "dependencies": {
+        "axios": "^0.26.0",
+        "debug": "^4.3.2",
+        "jsonwebtoken": "^9.0.0",
+        "lru-cache": "^6.0.0",
+        "node-rsa": "^1.1.1",
+        "valid-url": "1.0.9"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@sap/approuter/node_modules/@sap/xssec/node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
+    "node_modules/@sap/approuter/node_modules/@sap/xssec/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@sap/approuter/node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@sap/approuter/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/@sap/approuter/node_modules/agentkeepalive": {
@@ -2808,6 +2848,11 @@
         "pseudomap": "^1.0.1",
         "yallist": "^2.0.0"
       }
+    },
+    "node_modules/@sap/approuter/node_modules/lru-cache/node_modules/yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="
     },
     "node_modules/@sap/approuter/node_modules/mime": {
       "version": "1.4.1",
@@ -2959,11 +3004,6 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/@sap/approuter/node_modules/yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="
-    },
     "node_modules/@sap/audit-logging": {
       "version": "5.6.3",
       "resolved": "https://registry.npmjs.org/@sap/audit-logging/-/audit-logging-5.6.3.tgz",
@@ -3113,12 +3153,12 @@
       "version": "4.0.0"
     },
     "node_modules/@sap/cds": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@sap/cds/-/cds-7.0.2.tgz",
-      "integrity": "sha512-UJbwkNMoWuAB20uugvcHIVKP40/NRtQYoILYXWXgY2wIJ3WQ+HFZwExYbgTCgpeKDSzaFtJ5Kg+YDXKFi8MXQQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sap/cds/-/cds-7.2.0.tgz",
+      "integrity": "sha512-UKWDZuqND0NfPLUYBCn/hZaOpdbIygULwktmAqcsCeil4Dt7x8/316RRWKTN6NV13r6v6AvaOlKa7Uofj9j3RA==",
       "dependencies": {
-        "@sap/cds-compiler": ">=3.9",
-        "@sap/cds-fiori": "*",
+        "@sap/cds-compiler": "^4",
+        "@sap/cds-fiori": "^1",
         "@sap/cds-foss": "^4"
       },
       "bin": {
@@ -3130,9 +3170,9 @@
       }
     },
     "node_modules/@sap/cds-compiler": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@sap/cds-compiler/-/cds-compiler-4.0.2.tgz",
-      "integrity": "sha512-d2S7LpV0xL/v0Pdw7CUN21WdE1FY4VKt44FnpiFJP/FF3upRjk0wS9BhQ2a1NT1Z2piNOWvAN6I8vJW171zjcQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@sap/cds-compiler/-/cds-compiler-4.2.2.tgz",
+      "integrity": "sha512-JnAmZ/dZiBrkQD0z/8zntgCnZ+5urHZCMB4/WNVqwuLdbaErY/OsQNyu+8xlhbS5iy5wzwndWEUGjacnJ7839w==",
       "dependencies": {
         "antlr4": "4.9.3"
       },
@@ -3146,9 +3186,9 @@
       }
     },
     "node_modules/@sap/cds-fiori": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@sap/cds-fiori/-/cds-fiori-1.0.0.tgz",
-      "integrity": "sha512-DCYV5sQwAqWV4nXvtwn4o5Ig070XX68KtFdmX0IEi3IDMtyID4rGDFwEXVKNZMNAA9kdTLN8BBIAvAFna7jVSw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@sap/cds-fiori/-/cds-fiori-1.1.0.tgz",
+      "integrity": "sha512-dj+OMS3bpbYx7pO/SUSbZkt2KIs2RiAnaxhO+RZmL89DR8r67MEft2/vQbg00AGoH0Al/NKK0AFiHHyNL/+CWg==",
       "peerDependencies": {
         "@sap/cds": ">=7",
         "express": ">=4"
@@ -3340,9 +3380,9 @@
       }
     },
     "node_modules/@sap/xssec": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@sap/xssec/-/xssec-3.3.0.tgz",
-      "integrity": "sha512-WCmalrfAjpqb3HOclWVwrwm6TSFZVO6l/nrnQ4ADR/xTeXkUz40PokHWqa5XDuCi6aL/xOFAk6+VVnIhGA15Lw==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@sap/xssec/-/xssec-3.3.4.tgz",
+      "integrity": "sha512-8wZp4khPygJsg6B7nYergFj0720glMHx/G2UDk9vYW/ZDTSF0n2OJT0Ifj7aOtrAmezvT3H7MD4idjZpsGSCLA==",
       "dependencies": {
         "axios": "^0.26.0",
         "debug": "^4.3.2",
@@ -3427,6 +3467,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "dev": true,
       "engines": {
         "node": ">= 10"
       }
@@ -3506,9 +3547,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.4.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.2.tgz",
-      "integrity": "sha512-Dd0BYtWgnWJKwO1jkmTrzofjK2QXXcai0dmtzvIBhcA+RsG5h8R3xlyta0kGOZRNfL9GuRtb1knmPEhQrePCEw=="
+      "version": "20.5.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.9.tgz",
+      "integrity": "sha512-PcGNd//40kHAS3sTlzKB9C9XL4K0sTup8nbG5lC14kzEteTNuAFh9u5nA0o5TWnSG2r/JNPRXFVcHJIIeRlmqQ=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -3698,6 +3739,35 @@
         }
       }
     },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@typescript-eslint/utils": {
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.6.0.tgz",
@@ -3791,16 +3861,16 @@
       }
     },
     "node_modules/@ui5/cli": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@ui5/cli/-/cli-3.5.0.tgz",
-      "integrity": "sha512-nAF1wzOS9ewvUrPLrt/I6uksdoR0mEg0xp7SM6R2ln7hUKBEhOKAgj3MtLNL81uO5ieQPs1PLyAAfdFdhs6VaQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@ui5/cli/-/cli-3.6.0.tgz",
+      "integrity": "sha512-BPJ8Y/p+QY+hjS+vNwzQyN2UUhkcT1zCT3fJDw0pVNb274VeG6JVWfHQoS/N2OuyGUpdR5Rm8yuNyWICTjBlBQ==",
       "dev": true,
       "hasShrinkwrap": true,
       "dependencies": {
         "@ui5/builder": "^3.0.9",
         "@ui5/fs": "^3.0.4",
         "@ui5/logger": "^3.0.0",
-        "@ui5/project": "^3.6.0",
+        "@ui5/project": "^3.7.0",
         "@ui5/server": "^3.1.3",
         "chalk": "^5.3.0",
         "data-with-position": "^0.5.0",
@@ -3827,12 +3897,12 @@
       "dev": true
     },
     "node_modules/@ui5/cli/node_modules/@babel/code-frame": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.10.tgz",
-      "integrity": "sha512-/KKIMG4UEL35WmI9OlvMhurwtytjvXoFcGNrOvyG9zIzA8YmPjVtIZUf7b05+TPO7G7/GEmLHDaoCgACHl9hhA==",
+      "version": "7.22.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
+      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.22.10",
+        "@babel/highlight": "^7.22.13",
         "chalk": "^2.4.2"
       },
       "engines": {
@@ -3905,9 +3975,9 @@
       }
     },
     "node_modules/@ui5/cli/node_modules/@babel/highlight": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.10.tgz",
-      "integrity": "sha512-78aUtVcT7MUscr0K5mIEnkwxPE0MaxkR5RxRwuHaQ+JuU5AmTPhY+do2mdzVTnIJJpyBglql2pehuBIWHug+WQ==",
+      "version": "7.22.13",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.13.tgz",
+      "integrity": "sha512-C/BaXcnnvBCmHTpz/VGZ8jgtE2aYlW4hxDhseJAWZb7gqGM/qtCK6iZUb0TyKFf7BOUsBH7Q7fkRsDRhg1XklQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.22.5",
@@ -3975,9 +4045,9 @@
       }
     },
     "node_modules/@ui5/cli/node_modules/@babel/parser": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.10.tgz",
-      "integrity": "sha512-lNbdGsQb9ekfsnjFGhEiF4hfFqGgfOP3H3d27re3n+CGhNuTSUEQdfWk556sTLNTloczcdM5TYF2LhzmDQKyvQ==",
+      "version": "7.22.14",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.14.tgz",
+      "integrity": "sha512-1KucTHgOvaw/LzCVrEOAyXkr9rQlp0A1HiHRYnSUE9dmb8PvPW7o5sscg+5169r54n3vGlbx6GevTE/Iw/P3AQ==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -4473,9 +4543,9 @@
       "dev": true
     },
     "node_modules/@ui5/cli/node_modules/@types/linkify-it": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
-      "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.3.tgz",
+      "integrity": "sha512-pTjcqY9E4nOI55Wgpz7eiI8+LzdYnw3qxXCfHyBDdPbYvbyLgWLJGh8EdPvqawwMK1Uo1794AUkkR38Fr0g+2g==",
       "dev": true
     },
     "node_modules/@ui5/cli/node_modules/@types/markdown-it": {
@@ -4565,9 +4635,9 @@
       }
     },
     "node_modules/@ui5/cli/node_modules/@ui5/project": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@ui5/project/-/project-3.6.0.tgz",
-      "integrity": "sha512-5A2nxPeRVYP5j1j9fVbGY5gkkdyf7xdDz3X4PRrl482MIZl5/X5YvnKhxYHRfzkmbzWVVxl7aitOQQrOymaoJw==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@ui5/project/-/project-3.7.0.tgz",
+      "integrity": "sha512-Qyz70vxcxdFjxENIOH1eswskZA80WTcIvus9gMhtFP+Iuc6lUbc4HVVaiNuT6tb72bOUsi/tv7Z83tnvg58Bdw==",
       "dev": true,
       "dependencies": {
         "@npmcli/config": "^6.2.1",
@@ -4586,8 +4656,8 @@
         "node-stream-zip": "^1.15.0",
         "pacote": "^15.2.0",
         "pretty-hrtime": "^1.0.3",
-        "read-pkg": "^8.0.0",
-        "read-pkg-up": "^10.0.0",
+        "read-pkg": "^8.1.0",
+        "read-pkg-up": "^10.1.0",
         "resolve": "^1.22.4",
         "rimraf": "^5.0.1",
         "semver": "^7.5.4",
@@ -5107,6 +5177,18 @@
         "node": ">=14.16"
       }
     },
+    "node_modules/@ui5/cli/node_modules/cacheable-request/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@ui5/cli/node_modules/call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -5455,6 +5537,12 @@
         "url": "https://github.com/yeoman/configstore?sponsor=1"
       }
     },
+    "node_modules/@ui5/cli/node_modules/configstore/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
+    },
     "node_modules/@ui5/cli/node_modules/configstore/node_modules/write-file-atomic": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
@@ -5742,6 +5830,18 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/@ui5/cli/node_modules/default-browser/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@ui5/cli/node_modules/default-browser/node_modules/human-signals": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
@@ -5750,6 +5850,12 @@
       "engines": {
         "node": ">=14.18.0"
       }
+    },
+    "node_modules/@ui5/cli/node_modules/default-browser/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
     },
     "node_modules/@ui5/cli/node_modules/defer-to-connect": {
       "version": "2.0.1",
@@ -6416,18 +6522,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@ui5/cli/node_modules/foreground-child/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@ui5/cli/node_modules/form-data-encoder": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
@@ -6507,6 +6601,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/@ui5/cli/node_modules/gauge/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
+    },
     "node_modules/@ui5/cli/node_modules/gauge/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -6552,22 +6652,10 @@
         "node": ">=4"
       }
     },
-    "node_modules/@ui5/cli/node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@ui5/cli/node_modules/glob": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.3.tgz",
-      "integrity": "sha512-92vPiMb/iqpmEgsOoIDvTjc50wf9CCCvMzsi6W0JLPeUKE8TWP1a73PgqSrqy7iAZxaSD1YdzU7QZR5LF51MJw==",
+      "version": "10.3.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.4.tgz",
+      "integrity": "sha512-6LFElP3A+i/Q8XQKEvZjkEWEOTgAIALR9AO2rwT8bgPhDd1anmqDJDZ6lLddI4ehxxxR1S5RIqKe1uapMQfYaQ==",
       "dev": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -6664,6 +6752,18 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/@ui5/cli/node_modules/got/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@ui5/cli/node_modules/graceful-fs": {
@@ -7231,9 +7331,9 @@
       "dev": true
     },
     "node_modules/@ui5/cli/node_modules/jackspeak": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.0.tgz",
-      "integrity": "sha512-uKmsITSsF4rUWQHzqaRUuyAir3fZfW3f202Ee34lz/gZCi970CPZwyQXLGNgWJvvZbvFyzeyGq0+4fcG/mBKZg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.1.tgz",
+      "integrity": "sha512-4iSY3Bh1Htv+kLhiiZunUhQ+OYXIn0ze3ulq8JeWrFKmhPAJSySV2+kdtRh2pGcCeF0s6oR8Oc+pYZynJj4t8A==",
       "dev": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -7423,6 +7523,12 @@
       "dependencies": {
         "signal-exit": "^3.0.2"
       }
+    },
+    "node_modules/@ui5/cli/node_modules/lockfile/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
     },
     "node_modules/@ui5/cli/node_modules/lodash": {
       "version": "4.17.21",
@@ -8839,15 +8945,15 @@
       }
     },
     "node_modules/@ui5/cli/node_modules/read-pkg": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-8.0.0.tgz",
-      "integrity": "sha512-Ajb9oSjxXBw0YyOiwtQ2dKbAA/vMnUPnY63XcCk+mXo0BwIdQEMgZLZiMWGttQHcUhUgbK0mH85ethMPKXxziw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-8.1.0.tgz",
+      "integrity": "sha512-PORM8AgzXeskHO/WEv312k9U03B8K9JSiWF/8N9sUuFjBa+9SF2u6K7VClzXwDXab51jCd8Nd36CNM+zR97ScQ==",
       "dev": true,
       "dependencies": {
         "@types/normalize-package-data": "^2.4.1",
-        "normalize-package-data": "^5.0.0",
+        "normalize-package-data": "^6.0.0",
         "parse-json": "^7.0.0",
-        "type-fest": "^3.8.0"
+        "type-fest": "^4.2.0"
       },
       "engines": {
         "node": ">=16"
@@ -8857,14 +8963,14 @@
       }
     },
     "node_modules/@ui5/cli/node_modules/read-pkg-up": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-10.0.0.tgz",
-      "integrity": "sha512-jgmKiS//w2Zs+YbX039CorlkOp8FIVbSAN8r8GJHDsGlmNPXo+VeHkqAwCiQVTTx5/LwLZTcEw59z3DvcLbr0g==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-10.1.0.tgz",
+      "integrity": "sha512-aNtBq4jR8NawpKJQldrQcSW9y/d+KWH4v24HWkHljOZ7H0av+YTGANBzRh9A5pw7v/bLVsLVPpOhJ7gHNVy8lA==",
       "dev": true,
       "dependencies": {
         "find-up": "^6.3.0",
-        "read-pkg": "^8.0.0",
-        "type-fest": "^3.12.0"
+        "read-pkg": "^8.1.0",
+        "type-fest": "^4.2.0"
       },
       "engines": {
         "node": ">=16"
@@ -8944,12 +9050,12 @@
       }
     },
     "node_modules/@ui5/cli/node_modules/read-pkg-up/node_modules/type-fest": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
-      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.3.1.tgz",
+      "integrity": "sha512-pphNW/msgOUSkJbH58x8sqpq8uQj6b0ZKGxEsLKMUnGorRcDjrUaLS+39+/ub41JNTwrrMyJcUB8+YZs3mbwqw==",
       "dev": true,
       "engines": {
-        "node": ">=14.16"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8968,15 +9074,15 @@
       }
     },
     "node_modules/@ui5/cli/node_modules/read-pkg/node_modules/hosted-git-info": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.1.tgz",
-      "integrity": "sha512-r0EI+HBMcXadMrugk0GCQ+6BQV39PiWAZVfq7oIckeGiN7sjRGyQxPdft3nQekFTCQbYxLBH+/axZMeH8UX6+w==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.0.tgz",
+      "integrity": "sha512-ICclEpTLhHj+zCuSb2/usoNXSVkxUSIopre+b1w8NDY9Dntp9LO4vLdHYI336TH8sAqwrRgnSfdkBG2/YpisHA==",
       "dev": true,
       "dependencies": {
-        "lru-cache": "^7.5.1"
+        "lru-cache": "^10.0.1"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/@ui5/cli/node_modules/read-pkg/node_modules/json-parse-even-better-errors": {
@@ -8998,33 +9104,33 @@
       }
     },
     "node_modules/@ui5/cli/node_modules/read-pkg/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
+      "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
       "dev": true,
       "engines": {
-        "node": ">=12"
+        "node": "14 || >=16.14"
       }
     },
     "node_modules/@ui5/cli/node_modules/read-pkg/node_modules/normalize-package-data": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-5.0.0.tgz",
-      "integrity": "sha512-h9iPVIfrVZ9wVYQnxFgtw1ugSvGEMOlyPWWtm8BMJhnwyEL/FLbYbTY3V3PpjI/BUK67n9PEWDu6eHzu1fB15Q==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.0.tgz",
+      "integrity": "sha512-UL7ELRVxYBHBgYEtZCXjxuD5vPxnmvMGq0jp/dGPKKrN7tfsBh2IY7TlJ15WWwdjRWD3RJbnsygUurTK3xkPkg==",
       "dev": true,
       "dependencies": {
-        "hosted-git-info": "^6.0.0",
+        "hosted-git-info": "^7.0.0",
         "is-core-module": "^2.8.1",
         "semver": "^7.3.5",
         "validate-npm-package-license": "^3.0.4"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/@ui5/cli/node_modules/read-pkg/node_modules/parse-json": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-7.0.0.tgz",
-      "integrity": "sha512-kP+TQYAzAiVnzOlWOe0diD6L35s9bJh0SCn95PIbZFKrOYuIRQsQkeWEYxzVDuHTt9V9YqvYCJ2Qo4z9wdfZPw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-7.1.0.tgz",
+      "integrity": "sha512-ihtdrgbqdONYD156Ap6qTcaGcGdkdAxodO1wLqQ/j7HP1u2sFYppINiq4jyC8F+Nm+4fVufylCV00QmkTHkSUg==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.21.4",
@@ -9040,13 +9146,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@ui5/cli/node_modules/read-pkg/node_modules/type-fest": {
+    "node_modules/@ui5/cli/node_modules/read-pkg/node_modules/parse-json/node_modules/type-fest": {
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
       "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
       "dev": true,
       "engines": {
         "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ui5/cli/node_modules/read-pkg/node_modules/type-fest": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.3.1.tgz",
+      "integrity": "sha512-pphNW/msgOUSkJbH58x8sqpq8uQj6b0ZKGxEsLKMUnGorRcDjrUaLS+39+/ub41JNTwrrMyJcUB8+YZs3mbwqw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -9328,6 +9446,18 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/@ui5/cli/node_modules/run-applescript/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@ui5/cli/node_modules/run-applescript/node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -9384,6 +9514,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@ui5/cli/node_modules/run-applescript/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
     },
     "node_modules/@ui5/cli/node_modules/run-applescript/node_modules/strip-final-newline": {
       "version": "2.0.0",
@@ -9591,10 +9727,16 @@
       }
     },
     "node_modules/@ui5/cli/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/@ui5/cli/node_modules/sigstore": {
       "version": "1.9.0",
@@ -10027,9 +10169,9 @@
       "dev": true
     },
     "node_modules/@ui5/cli/node_modules/terser": {
-      "version": "5.19.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.2.tgz",
-      "integrity": "sha512-qC5+dmecKJA4cpYxRa5aVkKehYsQKc+AHeKl0Oe62aYjBL8ZA33tTljktDHJSaxxMnbI5ZYw+o/S2DxxLu8OfA==",
+      "version": "5.19.3",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.3.tgz",
+      "integrity": "sha512-pQzJ9UJzM0IgmT4FAtYI6+VqFf0lj/to58AV0Xfgg0Up37RyPG7Al+1cepC6/BVuAxR9oNb41/DL4DEoHJvTdg==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -10343,9 +10485,9 @@
       }
     },
     "node_modules/@ui5/cli/node_modules/workerpool": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.4.1.tgz",
-      "integrity": "sha512-zIK7qRgM1Mk+ySxOJl7ZpjX6SlKt5gugxzl8eXHPdbpXX8iDAaVIxYJz4Apn6JdDxP2buY/Ekqg0bOLNSf0u0g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.4.2.tgz",
+      "integrity": "sha512-MrDWwemtC4xNV22kbbZDQQQmxNX+yLm790sgYl2wVD3CWnK7LJY1youI/11wHorAjHjK+GEjUxUh74XoPU71uQ==",
       "dev": true
     },
     "node_modules/@ui5/cli/node_modules/wrap-ansi": {
@@ -10575,37 +10717,6 @@
         "npm": ">= 8"
       }
     },
-    "node_modules/@ui5/fs/node_modules/globby": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
-      "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
-      "dev": true,
-      "dependencies": {
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.3.0",
-        "ignore": "^5.2.4",
-        "merge2": "^1.4.1",
-        "slash": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@ui5/fs/node_modules/slash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@ui5/logger": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@ui5/logger/-/logger-3.0.0.tgz",
@@ -10634,9 +10745,9 @@
       }
     },
     "node_modules/@ui5/project": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@ui5/project/-/project-3.6.0.tgz",
-      "integrity": "sha512-5A2nxPeRVYP5j1j9fVbGY5gkkdyf7xdDz3X4PRrl482MIZl5/X5YvnKhxYHRfzkmbzWVVxl7aitOQQrOymaoJw==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@ui5/project/-/project-3.7.0.tgz",
+      "integrity": "sha512-Qyz70vxcxdFjxENIOH1eswskZA80WTcIvus9gMhtFP+Iuc6lUbc4HVVaiNuT6tb72bOUsi/tv7Z83tnvg58Bdw==",
       "dev": true,
       "dependencies": {
         "@npmcli/config": "^6.2.1",
@@ -10655,8 +10766,8 @@
         "node-stream-zip": "^1.15.0",
         "pacote": "^15.2.0",
         "pretty-hrtime": "^1.0.3",
-        "read-pkg": "^8.0.0",
-        "read-pkg-up": "^10.0.0",
+        "read-pkg": "^8.1.0",
+        "read-pkg-up": "^10.1.0",
         "resolve": "^1.22.4",
         "rimraf": "^5.0.1",
         "semver": "^7.5.4",
@@ -10678,37 +10789,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@ui5/project/node_modules/globby": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
-      "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
-      "dev": true,
-      "dependencies": {
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.3.0",
-        "ignore": "^5.2.4",
-        "merge2": "^1.4.1",
-        "slash": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@ui5/project/node_modules/slash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@ui5/project/node_modules/xml2js": {
@@ -10833,14 +10913,14 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
       "dependencies": {
-        "debug": "4"
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 14"
       }
     },
     "node_modules/agentkeepalive": {
@@ -10982,16 +11062,16 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
     "node_modules/array-includes": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
-      "integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.7.tgz",
+      "integrity": "sha512-dlcsNBIiWhPkHdOEEKnehA+RNUWDc4UqFtnIXU4uuYDPtA4LDkr7qip2p0VvFAEXNDr0yWZ9PJyIRiGjRLQzwQ==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
-        "get-intrinsic": "^1.1.3",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "get-intrinsic": "^1.2.1",
         "is-string": "^1.0.7"
       },
       "engines": {
@@ -11016,16 +11096,36 @@
         "node": ">=8"
       }
     },
-    "node_modules/array.prototype.flat": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
-      "integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
+    "node_modules/array.prototype.findlastindex": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.3.tgz",
+      "integrity": "sha512-LzLoiOMAxvy+Gd3BAq3B7VeIgPdo+Q8hthvKtXybMvRV0jrXfJM/t8mw7nNlpEcVlVUnCnM2KSX4XU5HmpodOA==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "es-shim-unscopables": "^1.0.0",
+        "get-intrinsic": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
+      "integrity": "sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
         "es-shim-unscopables": "^1.0.0"
       },
       "engines": {
@@ -11055,15 +11155,16 @@
       }
     },
     "node_modules/arraybuffer.prototype.slice": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.1.tgz",
-      "integrity": "sha512-09x0ZWFEjj4WD8PDbykUwo3t9arLn8NIzmmYEJFpYekOAQjpkGSyrQhNoRTcwwcFRu+ycWF78QZ63oWTqSjBcw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.2.tgz",
+      "integrity": "sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "array-buffer-byte-length": "^1.0.0",
         "call-bind": "^1.0.2",
         "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
         "get-intrinsic": "^1.2.1",
         "is-array-buffer": "^3.0.2",
         "is-shared-array-buffer": "^1.0.2"
@@ -11127,9 +11228,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
+      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -11508,9 +11609,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001525",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001525.tgz",
-      "integrity": "sha512-/3z+wB4icFt3r0USMwxujAqRvaD/B7rvGTsKhbhSQErVrJvkZCLhgNLJxU8MevahQVH6hCU9FsHdNUFbiwmE7Q==",
+      "version": "1.0.30001527",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001527.tgz",
+      "integrity": "sha512-YkJi7RwPgWtXVSgK4lG9AHH57nSzvvOp9MesgXmw4Q7n0C3H04L0foHqfxcmSAm5AcWb8dW9AYj2tR7/5GnddQ==",
       "dev": true,
       "funding": [
         {
@@ -11540,9 +11641,9 @@
       }
     },
     "node_modules/cds-plugin-ui5": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/cds-plugin-ui5/-/cds-plugin-ui5-0.5.1.tgz",
-      "integrity": "sha512-3cZngD2sYzGWp+dDwXdqt0fE+h8hWyRNqbmtUfFRjBaQrd5PahRMr95GAiJvLn7ec02m7NIDJV5HZnQYwwH9ng==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/cds-plugin-ui5/-/cds-plugin-ui5-0.5.2.tgz",
+      "integrity": "sha512-AGB/Tj6AOodZIr3hNEZWeodSG+SURDm4sziz5EJIvhWUNPFbg1+lcpJ8OLAEluvPIpBKOc1Rh7W28ZNQRhcE+g==",
       "dev": true,
       "dependencies": {
         "@ui5/fs": "^3.0.4",
@@ -12436,9 +12537,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.508",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.508.tgz",
-      "integrity": "sha512-FFa8QKjQK/A5QuFr2167myhMesGrhlOBD+3cYNxO9/S4XzHEXesyTD/1/xF644gC8buFPz3ca6G1LOQD0tZrrg==",
+      "version": "1.4.509",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.509.tgz",
+      "integrity": "sha512-G5KlSWY0zzhANtX15tkikHl4WB7zil2Y65oT52EZUL194abjUXBZym12Ht7Bhuwm/G3LJFEqMADyv2Cks56dmg==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -12663,27 +12764,27 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.45.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.45.0.tgz",
-      "integrity": "sha512-pd8KSxiQpdYRfYa9Wufvdoct3ZPQQuVuU5O6scNgMuOMYuxvH0IGaYK0wUFjo4UYYQQCUndlXiMbnxopwvvTiw==",
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.48.0.tgz",
+      "integrity": "sha512-sb6DLeIuRXxeM1YljSe1KEx9/YYeZFQWcV8Rq9HfigmdDEugjLEVEa1ozDjL6YDjBpQHPJxJzze+alxi4T3OLg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.4.0",
-        "@eslint/eslintrc": "^2.1.0",
-        "@eslint/js": "8.44.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.2",
+        "@eslint/js": "8.48.0",
         "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
-        "ajv": "^6.10.0",
+        "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.2.0",
-        "eslint-visitor-keys": "^3.4.1",
-        "espree": "^9.6.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -12717,9 +12818,9 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
-      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.0.0.tgz",
+      "integrity": "sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==",
       "dev": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
@@ -12758,15 +12859,15 @@
       }
     },
     "node_modules/eslint-import-resolver-node": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.7.tgz",
-      "integrity": "sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "debug": "^3.2.7",
-        "is-core-module": "^2.11.0",
-        "resolve": "^1.22.1"
+        "is-core-module": "^2.13.0",
+        "resolve": "^1.22.4"
       }
     },
     "node_modules/eslint-import-resolver-node/node_modules/debug": {
@@ -12827,14 +12928,14 @@
       }
     },
     "node_modules/eslint-plugin-es-x": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.1.0.tgz",
-      "integrity": "sha512-AhiaF31syh4CCQ+C5ccJA0VG6+kJK8+5mXKKE7Qs1xcPRg02CDPOj3mWlQxuWS/AYtg7kxrDNgW9YW3vc0Q+Mw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.2.0.tgz",
+      "integrity": "sha512-9dvv5CcvNjSJPqnS5uZkqb3xmbeqRLnvXKK7iI5+oK/yTusyc46zbBZKENGsOfojm/mKfszyZb+wNqNPAPeGXA==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.1.2",
-        "@eslint-community/regexpp": "^4.5.0"
+        "@eslint-community/regexpp": "^4.6.0"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -12847,27 +12948,29 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.27.5",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz",
-      "integrity": "sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==",
+      "version": "2.28.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.28.1.tgz",
+      "integrity": "sha512-9I9hFlITvOV55alzoKBI+K9q74kv0iKMeY6av5+umsNwayt59fz692daGyjR+oStBQgx6nwR9rXldDev3Clw+A==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "array-includes": "^3.1.6",
+        "array.prototype.findlastindex": "^1.2.2",
         "array.prototype.flat": "^1.3.1",
         "array.prototype.flatmap": "^1.3.1",
         "debug": "^3.2.7",
         "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.7",
-        "eslint-module-utils": "^2.7.4",
+        "eslint-module-utils": "^2.8.0",
         "has": "^1.0.3",
-        "is-core-module": "^2.11.0",
+        "is-core-module": "^2.13.0",
         "is-glob": "^4.0.3",
         "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.6",
+        "object.groupby": "^1.0.0",
         "object.values": "^1.1.6",
-        "resolve": "^1.22.1",
-        "semver": "^6.3.0",
-        "tsconfig-paths": "^3.14.1"
+        "semver": "^6.3.1",
+        "tsconfig-paths": "^3.14.2"
       },
       "engines": {
         "node": ">=4"
@@ -12934,9 +13037,9 @@
       }
     },
     "node_modules/eslint-plugin-n": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-16.0.1.tgz",
-      "integrity": "sha512-CDmHegJN0OF3L5cz5tATH84RPQm9kG+Yx39wIqIwPR2C0uhBGMWfbbOtetR83PQjjidA5aXMu+LEFw1jaSwvTA==",
+      "version": "16.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-16.0.2.tgz",
+      "integrity": "sha512-Y66uDfUNbBzypsr0kELWrIz+5skicECrLUqlWuXawNSLUq3ltGlCwu6phboYYOTSnoTdHgTLrc+5Ydo6KjzZog==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -13048,9 +13151,9 @@
       }
     },
     "node_modules/eslint-plugin-sonarjs": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-0.19.0.tgz",
-      "integrity": "sha512-6+s5oNk5TFtVlbRxqZN7FIGmjdPCYQKaTzFPmqieCmsU1kBYDzndTeQav0xtQNwZJWu5awWfTGe8Srq9xFOGnw==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-0.21.0.tgz",
+      "integrity": "sha512-oezUDfFT5S6j3rQheZ4DLPrbetPmMS7zHIKWGHr0CM3g5JgyZroz1FpIKa4jV83NsGpmgIeagpokWDKIJzRQmw==",
       "dev": true,
       "engines": {
         "node": ">=14"
@@ -13060,9 +13163,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.1.tgz",
-      "integrity": "sha512-CvefSOsDdaYYvxChovdrPo/ZGt8d5lrJWleAc1diXRKhHGiTYEI26cvo8Kle/wGnsizoCJjK73FMg1/IkIwiNA==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
       "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -13109,9 +13212,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
-      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -13590,16 +13693,17 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.1.0.tgz",
+      "integrity": "sha512-OHx4Qwrrt0E4jEIcI5/Xb+f+QmJYNj2rrK8wiIdQOIrB9WrrJL8cjZvXdXuBTkkEwEqLycb5BeZDV1o2i9bTew==",
       "dev": true,
       "dependencies": {
-        "flatted": "^3.1.0",
+        "flatted": "^3.2.7",
+        "keyv": "^4.5.3",
         "rimraf": "^3.0.2"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/flat-cache/node_modules/brace-expansion": {
@@ -13762,22 +13866,36 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "node_modules/function.prototype.name": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
-      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
+      "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0",
-        "functions-have-names": "^1.2.2"
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "functions-have-names": "^1.2.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -13922,9 +14040,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.20.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+      "version": "13.21.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
+      "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -13953,20 +14071,19 @@
       }
     },
     "node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
+      "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
       "dev": true,
       "dependencies": {
-        "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
+        "fast-glob": "^3.3.0",
+        "ignore": "^5.2.4",
         "merge2": "^1.4.1",
-        "slash": "^3.0.0"
+        "slash": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -14223,6 +14340,17 @@
         "tough-cookie": "^4.0.0"
       }
     },
+    "node_modules/http-cookie-agent/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/http-deceiver": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
@@ -14266,16 +14394,15 @@
       }
     },
     "node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
+      "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
       "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/http-proxy-middleware": {
@@ -14302,15 +14429,15 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
       "dependencies": {
-        "agent-base": "6",
+        "agent-base": "^7.0.2",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/humanize-ms": {
@@ -14714,6 +14841,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-string": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
@@ -14907,6 +15045,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.0.tgz",
@@ -14956,14 +15100,20 @@
       ]
     },
     "node_modules/jsonwebtoken": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.1.tgz",
-      "integrity": "sha512-K8wx7eJ5TPvEjuiVSkv167EVboBDv9PZdDoF7BgeQnBLVvZWW9clr2PsQHVJDTKaEIH5JBIwHujGcHp7GgI2eg==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
       "dependencies": {
         "jws": "^3.2.2",
-        "lodash": "^4.17.21",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
         "ms": "^2.1.1",
-        "semver": "^7.3.8"
+        "semver": "^7.5.4"
       },
       "engines": {
         "node": ">=12",
@@ -14993,6 +15143,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.0.1.tgz",
       "integrity": "sha512-/KEXk2wGfWoSM2SHQk8mq9n/Rd6ahB0XIZt0jEcNy4tQXeDHU4oNOGK1shSVstIQm97qowy6dFgUAHB3zbOD8g=="
+    },
+    "node_modules/keyv": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
+      "integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
+      "dev": true,
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
     },
     "node_modules/klaw": {
       "version": "3.0.0",
@@ -15129,10 +15288,20 @@
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g=="
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
     "node_modules/lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
     },
     "node_modules/lodash.isfinite": {
       "version": "3.3.2",
@@ -15140,11 +15309,36 @@
       "integrity": "sha512-7FGG40uhC8Mm633uKW1r58aElFlBlxCrg9JfSi3P6aYiWmfiWF0PgMd86ZUsxE5GwWPdHoS2+48bwTh2VPkIQA==",
       "dev": true
     },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
     "node_modules/logform": {
       "version": "2.5.1",
@@ -15207,6 +15401,45 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/make-fetch-happen/node_modules/lru-cache": {
@@ -15611,9 +15844,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
-      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -16000,16 +16233,47 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/object.values": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.6.tgz",
-      "integrity": "sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==",
+    "node_modules/object.fromentries": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.7.tgz",
+      "integrity": "sha512-UPbPHML6sL8PI/mOqPwsH4G6iyXcCGzLin8KvEPenOZN5lpCNBZZQ+V62vdjB1mQHrmqGQt5/OJzemUA+KJmEA==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.groupby": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.1.tgz",
+      "integrity": "sha512-HqaQtqLnp/8Bn4GL16cj+CUYbnpe1bh0TtEaWvybszDG4tgxCJuRpV8VGuvNaI1fAnI4lUJzDG55MXcOH4JZcQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "get-intrinsic": "^1.2.1"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.7.tgz",
+      "integrity": "sha512-aU6xnDFYT3x17e/f0IiiwlGPTy2jzMySGfUB4fq6z7CV8l85CWHDk5ErhyhpfDHhrOMwGFhSQkhMGHaIotA6Ng==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -16060,11 +16324,11 @@
       }
     },
     "node_modules/opossum": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/opossum/-/opossum-7.1.0.tgz",
-      "integrity": "sha512-u3KZa2JTVsewFILe2NIebLMii/zzszTTBxRnM9USxVNcq2R2me40uP38/B39GueeOABXgWGtClPZPg4NAwHU4g==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/opossum/-/opossum-8.1.0.tgz",
+      "integrity": "sha512-HEdo+rD3Wxs52KpJrXx0BUHB1L/DxNcuU1ZK2Jk/fFv59swCVsBZahfGvQn+FNyfNs/dE4QCwFz0gFCKAFZcWA==",
       "engines": {
-        "node": "^19 || ^18 || ^16 || ^14"
+        "node": "^20 || ^18 || ^16"
       }
     },
     "node_modules/optionator": {
@@ -16418,9 +16682,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
-      "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
+      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -17211,14 +17475,14 @@
       }
     },
     "node_modules/safe-array-concat": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.0.tgz",
-      "integrity": "sha512-9dVEFruWIsnie89yym+xWTAYASdpw3CJV7Li/6zBewGf9z2i1j31rP6jnY0pHEO4QZh6N0K11bFjWmdR8UGdPQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
+      "integrity": "sha512-6XbUAseYE2KtOuGueyeobCySj9L4+66Tn6KQMOPQJrAJEowYKW/YR/MGJZl7FdydUdaFu4LYyDZjxf4/Nmo23Q==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.2.0",
+        "get-intrinsic": "^1.2.1",
         "has-symbols": "^1.0.3",
         "isarray": "^2.0.5"
       },
@@ -17450,12 +17714,15 @@
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
     "node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/smart-buffer": {
@@ -17494,6 +17761,18 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/source-map": {
@@ -17724,15 +18003,15 @@
       }
     },
     "node_modules/string.prototype.trimstart": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
-      "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.7.tgz",
+      "integrity": "sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -18126,9 +18405,9 @@
       "dev": true
     },
     "node_modules/ui5-middleware-cfdestination": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/ui5-middleware-cfdestination/-/ui5-middleware-cfdestination-3.1.3.tgz",
-      "integrity": "sha512-IvyHdBkMXUWXXFgc+qNaaW0EQ1mNp2vj2mMi6Oet42kpsNT6W83QgurVtej9gqXJfRO/px+yl12/1CbrjKRkig==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/ui5-middleware-cfdestination/-/ui5-middleware-cfdestination-3.1.4.tgz",
+      "integrity": "sha512-HoA3rqgULR/gh2gBVDHwGMwD57fP21bBo90wen4iyFQMO2O/12R1qjh0uakL/zNBh6DIhoOYuRe1cdyKXUYI9Q==",
       "dev": true,
       "dependencies": {
         "@sap/approuter": "^14.3.0",
@@ -18140,9 +18419,9 @@
       }
     },
     "node_modules/ui5-middleware-index": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ui5-middleware-index/-/ui5-middleware-index-3.0.1.tgz",
-      "integrity": "sha512-xVYoLlLBgZPEpzNK0GJ8k1IX9eebYHYVA4SFOK7lk62QRXjG2pRc7o8r0B8hHwa1TAgfDQeqByNuuLmT7/hpKg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/ui5-middleware-index/-/ui5-middleware-index-3.0.2.tgz",
+      "integrity": "sha512-+lBPo4SX/PdFbgABqk5QAdpdz4qaJjmuAZP38koZTUUypr7Reen4CF8ODaxs1cH5+u8UTaHQyRrheGE9SYhC2g==",
       "dev": true
     },
     "node_modules/ui5-middleware-livereload": {
@@ -18158,9 +18437,9 @@
       }
     },
     "node_modules/ui5-tooling-transpile": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ui5-tooling-transpile/-/ui5-tooling-transpile-3.2.0.tgz",
-      "integrity": "sha512-vmKW6xT/27YEJzwlw6ah4ECkSqxRl5fGFtb7N8bcVuAXrj+rBGNN+LQ8/vJunrZ4wUSP+gnIj6H/B/jybI+/+w==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/ui5-tooling-transpile/-/ui5-tooling-transpile-3.2.2.tgz",
+      "integrity": "sha512-s1pb1nM3tLSTpUdsVTjsUbZuvGc5zJu23K0B3hg1gSMyUbJIpyv8inNXOtvDznsGzDg/tyjOOP8XavazGf0JVA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.22.10",
@@ -18170,8 +18449,7 @@
         "babel-plugin-transform-remove-console": "^6.9.4",
         "babel-preset-transform-ui5": "^7.2.4",
         "browserslist": "^4.21.10",
-        "comment-json": "^4.2.3",
-        "parseurl": "^1.3.3"
+        "comment-json": "^4.2.3"
       },
       "peerDependencies": {
         "@ui5/ts-interface-generator": ">=0.8.0"
@@ -18564,17 +18842,6 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
       "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
-    "node_modules/winston/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/workerpool": {
       "version": "6.4.2",
       "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.4.2.tgz",
@@ -18752,9 +19019,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
-      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.2.tgz",
+      "integrity": "sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==",
       "engines": {
         "node": ">= 14"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,17 +11,17 @@
         "app"
       ],
       "dependencies": {
-        "@sap-cloud-sdk/connectivity": "^3.4.0",
-        "@sap-cloud-sdk/http-client": "^3.4.0",
+        "@sap-cloud-sdk/connectivity": "^3.5.0",
+        "@sap-cloud-sdk/http-client": "^3.5.0",
         "@sap/cds": "^7.2.0",
         "@sap/cds-odata-v2-adapter-proxy": "^1.9.21",
         "passport": "^0.6.0"
       },
       "devDependencies": {
-        "@prettier/plugin-xml": "^3.2.0",
+        "@prettier/plugin-xml": "^3.2.1",
         "@sap/eslint-plugin-cds": "^2.6.3",
-        "cds-plugin-ui5": "^0.5.2",
-        "eslint": "^8.48.0",
+        "cds-plugin-ui5": "^0.6.8",
+        "eslint": "^8.49.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-config-standard": "^17.1.0",
         "eslint-plugin-node": "^11.1.0",
@@ -36,19 +36,19 @@
       "name": "sample.ui5.uaa.ui",
       "version": "1.2.1",
       "dependencies": {
-        "@sap/approuter": "^14.3.1"
+        "@sap/approuter": "^14.3.2"
       },
       "devDependencies": {
-        "@sapui5/types": "^1.117.1",
-        "@typescript-eslint/eslint-plugin": "^6.6.0",
-        "@typescript-eslint/parser": "^6.6.0",
+        "@sapui5/types": "^1.118.0",
+        "@typescript-eslint/eslint-plugin": "^6.7.0",
+        "@typescript-eslint/parser": "^6.7.0",
         "@ui5/cli": "^3.6.0",
         "@ui5/ts-interface-generator": "^0.8.1",
         "typescript": "^5.2.2",
-        "ui5-middleware-cfdestination": "^3.1.4",
+        "ui5-middleware-cfdestination": "^3.2.0",
         "ui5-middleware-index": "^3.0.2",
         "ui5-middleware-livereload": "^3.0.0",
-        "ui5-tooling-transpile": "^3.2.2"
+        "ui5-tooling-transpile": "^3.2.3"
       },
       "engines": {
         "node": "^18"
@@ -2107,9 +2107,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.48.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.48.0.tgz",
-      "integrity": "sha512-ZSjtmelB7IJfWD2Fvb7+Z+ChTIKWq6kjda95fLcQKNS5aheVHn4IkfgRQE3sIIzTcSLwLcLZUD9UBt+V7+h+Pw==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.49.0.tgz",
+      "integrity": "sha512-1S8uAY/MTJqVx0SC4epBq+N2yhuwtNwLbJYNZyhL2pO1ZVKn5HFXav5T41Ryzy9K9V7ZId2JB2oy/W4aCd9/2w==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2534,9 +2534,9 @@
       }
     },
     "node_modules/@prettier/plugin-xml": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@prettier/plugin-xml/-/plugin-xml-3.2.0.tgz",
-      "integrity": "sha512-1SgnoMIOLjGcKqstr6gmly7J6VoVSXULz0kMDimBE36yj59GrNvaOBPjoeYUmcpU3/IwLiCIJRaCX8qiVSvy/A==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@prettier/plugin-xml/-/plugin-xml-3.2.1.tgz",
+      "integrity": "sha512-DvwnQPf8FsczapBVDm54IhR+Pryt3DbPZSNtUb9gOuFtgoUUPbPN69f3nQBMF5BEqh4ZjZjTaHBmsVno3UnAXQ==",
       "dev": true,
       "dependencies": {
         "@xml-tools/parser": "^1.0.11"
@@ -2546,49 +2546,98 @@
       }
     },
     "node_modules/@sap-cloud-sdk/connectivity": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@sap-cloud-sdk/connectivity/-/connectivity-3.4.0.tgz",
-      "integrity": "sha512-h0fSN1MNcAcU4QaIo8zELDs/45WGMXL2NCBPA+W6aiD0B/czBJhlQ+/WZXTUygE/CzzSzAn0iocoUaK0blB03w==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@sap-cloud-sdk/connectivity/-/connectivity-3.5.0.tgz",
+      "integrity": "sha512-NRVj7DZICEg0uFZxluBDU759zyqY0jIVE2vcYKqmSsdkV0Oc7zYJvQOWZGDlsUepig0Wkc/HX6W4DVgoNBOYbw==",
       "dependencies": {
-        "@sap-cloud-sdk/resilience": "^3.4.0",
-        "@sap-cloud-sdk/util": "^3.4.0",
-        "@sap/xsenv": "^3.4.0",
+        "@sap-cloud-sdk/resilience": "^3.5.0",
+        "@sap-cloud-sdk/util": "^3.5.0",
+        "@sap/xsenv": "^4.0.0",
         "@sap/xssec": "^3.2.17",
         "async-retry": "^1.3.3",
-        "axios": "^1.4.0",
+        "axios": "^1.5.0",
         "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.1",
-        "jsonwebtoken": "^9.0.1"
+        "https-proxy-agent": "^7.0.2",
+        "jsonwebtoken": "^9.0.2"
+      }
+    },
+    "node_modules/@sap-cloud-sdk/connectivity/node_modules/@sap/xsenv": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sap/xsenv/-/xsenv-4.0.0.tgz",
+      "integrity": "sha512-I3otC5A+WYt/4mnbgQmY1sx9OsLjcvhmDp800zLWqNMPbYy7FmnpgZ6TbECnsNL5pU1NOSHV9CNFpomdP/FBdg==",
+      "hasShrinkwrap": true,
+      "dependencies": {
+        "debug": "4.3.3",
+        "node-cache": "^5.1.0",
+        "verror": "1.10.0"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || ^16.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@sap-cloud-sdk/connectivity/node_modules/@sap/xsenv/node_modules/assert-plus": {
+      "version": "1.0.0"
+    },
+    "node_modules/@sap-cloud-sdk/connectivity/node_modules/@sap/xsenv/node_modules/clone": {
+      "version": "2.1.2"
+    },
+    "node_modules/@sap-cloud-sdk/connectivity/node_modules/@sap/xsenv/node_modules/core-util-is": {
+      "version": "1.0.2"
+    },
+    "node_modules/@sap-cloud-sdk/connectivity/node_modules/@sap/xsenv/node_modules/debug": {
+      "version": "4.3.3",
+      "dependencies": {
+        "ms": "2.1.2"
+      }
+    },
+    "node_modules/@sap-cloud-sdk/connectivity/node_modules/@sap/xsenv/node_modules/extsprintf": {
+      "version": "1.4.1"
+    },
+    "node_modules/@sap-cloud-sdk/connectivity/node_modules/@sap/xsenv/node_modules/ms": {
+      "version": "2.1.2"
+    },
+    "node_modules/@sap-cloud-sdk/connectivity/node_modules/@sap/xsenv/node_modules/node-cache": {
+      "version": "5.1.2",
+      "dependencies": {
+        "clone": "2.x"
+      }
+    },
+    "node_modules/@sap-cloud-sdk/connectivity/node_modules/@sap/xsenv/node_modules/verror": {
+      "version": "1.10.0",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
       }
     },
     "node_modules/@sap-cloud-sdk/http-client": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@sap-cloud-sdk/http-client/-/http-client-3.4.0.tgz",
-      "integrity": "sha512-7sNi8OtXp8oeTbP+/9Gn+l3k/2teLFVGukfICDpn0L89DxCNuh7W4ogwJNkWPUl/nFope+fuzpdgnCiMJBRo4Q==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@sap-cloud-sdk/http-client/-/http-client-3.5.0.tgz",
+      "integrity": "sha512-xDuMVWmygme5sa1fGNLMSDKWfe+zQmRfco07bekS3+NMVo8UMxa8pMds/Q7BEMvFEgt2sd+AhFph4Bt7ZdOAAA==",
       "dependencies": {
-        "@sap-cloud-sdk/connectivity": "^3.4.0",
-        "@sap-cloud-sdk/resilience": "^3.4.0",
-        "@sap-cloud-sdk/util": "^3.4.0",
-        "axios": "^1.4.0"
+        "@sap-cloud-sdk/connectivity": "^3.5.0",
+        "@sap-cloud-sdk/resilience": "^3.5.0",
+        "@sap-cloud-sdk/util": "^3.5.0",
+        "axios": "^1.5.0"
       }
     },
     "node_modules/@sap-cloud-sdk/resilience": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@sap-cloud-sdk/resilience/-/resilience-3.4.0.tgz",
-      "integrity": "sha512-ZT9gKJ9GQOOeplTNU4Z4UyRk1wGXFAdVNbv8HtHuMO5eGzqZahnPq7BP42puzsZDrPKccKxJYS9xeSaw9cbTdg==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@sap-cloud-sdk/resilience/-/resilience-3.5.0.tgz",
+      "integrity": "sha512-gVZNwzcpp9xXjN/rOCK9+PipkgFPyZGcyLdtl6LvnJa/QJcw1CO6h/7ud/G1HeLBNFn2bCDO2Q6TOJwOrBl5iw==",
       "dependencies": {
-        "@sap-cloud-sdk/util": "^3.4.0",
+        "@sap-cloud-sdk/util": "^3.5.0",
         "async-retry": "^1.3.3",
-        "axios": "^1.4.0",
-        "opossum": "^8.0.1"
+        "axios": "^1.5.0",
+        "opossum": "^8.1.0"
       }
     },
     "node_modules/@sap-cloud-sdk/util": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@sap-cloud-sdk/util/-/util-3.4.0.tgz",
-      "integrity": "sha512-9t91cJ1rdt7A7cbaizw62sJ1ImD9SviGNtQ5L51tcT5dTkFVdDFs63me1het0XAo7xdtfXO+VwkW3A4RojGrZw==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@sap-cloud-sdk/util/-/util-3.5.0.tgz",
+      "integrity": "sha512-5YTdHmfmH2GoXMvpdfwOIKng9o/VHVeFk6Qdxr/0Kob7c03v4lWH9XlGClR4zV0iysAAEF5mWeXW46hADqussA==",
       "dependencies": {
-        "axios": "^1.4.0",
+        "axios": "^1.5.0",
         "chalk": "^4.1.0",
         "logform": "^2.5.1",
         "voca": "^1.4.1",
@@ -2597,15 +2646,15 @@
       }
     },
     "node_modules/@sap/approuter": {
-      "version": "14.3.1",
-      "resolved": "https://registry.npmjs.org/@sap/approuter/-/approuter-14.3.1.tgz",
-      "integrity": "sha512-Ax9U8MmF0guUgzZQrZ16iJZJqmy/e2EhXVQ3+7IS3ol9SXmNk7L60hgh8llxo7yd373VndAxrRWegnjER9a/3w==",
+      "version": "14.3.2",
+      "resolved": "https://registry.npmjs.org/@sap/approuter/-/approuter-14.3.2.tgz",
+      "integrity": "sha512-HSernjo9pmAs3k1vu6uErN5L36pzeExi8uQ+OnJaSKfc/XSEkxM6s0K3z+8do5NavN24KGKkSZBOmg8yl/jhUw==",
       "dependencies": {
         "@sap/audit-logging": "5.6.3",
         "@sap/e2e-trace": "^3.0.0",
         "@sap/logging": "^6.2.0",
         "@sap/xsenv": "^3.4.0",
-        "@sap/xssec": "3.3.0",
+        "@sap/xssec": "3.3.4",
         "agentkeepalive": "2.0.5",
         "axios": "0.27.2",
         "axios-cookiejar-support": "2.0.3",
@@ -2653,41 +2702,6 @@
       },
       "engines": {
         "node": "^16.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@sap/approuter/node_modules/@sap/xssec": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@sap/xssec/-/xssec-3.3.0.tgz",
-      "integrity": "sha512-WCmalrfAjpqb3HOclWVwrwm6TSFZVO6l/nrnQ4ADR/xTeXkUz40PokHWqa5XDuCi6aL/xOFAk6+VVnIhGA15Lw==",
-      "dependencies": {
-        "axios": "^0.26.0",
-        "debug": "^4.3.2",
-        "jsonwebtoken": "^9.0.0",
-        "lru-cache": "^6.0.0",
-        "node-rsa": "^1.1.1",
-        "valid-url": "1.0.9"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@sap/approuter/node_modules/@sap/xssec/node_modules/axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-      "dependencies": {
-        "follow-redirects": "^1.14.8"
-      }
-    },
-    "node_modules/@sap/approuter/node_modules/@sap/xssec/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@sap/approuter/node_modules/@tootallnate/once": {
@@ -3404,9 +3418,9 @@
       }
     },
     "node_modules/@sapui5/types": {
-      "version": "1.117.1",
-      "resolved": "https://registry.npmjs.org/@sapui5/types/-/types-1.117.1.tgz",
-      "integrity": "sha512-7mAr+HLF1FdK7b4n9R3OHazv43RbjoucqfEVUQPgDpj7dT63U8E3gj21NUQ7J17hLXd7eQLtsGudTqDLLHz1QA==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@sapui5/types/-/types-1.118.0.tgz",
+      "integrity": "sha512-exMkYmX5ga4X73JBCyvazIMUhtK84s3R11fkIEnG6GjAdxJCBxqzD7yhj21GgsmRrz70c1suCH1UHypUy05xrA==",
       "dev": true,
       "dependencies": {
         "@types/jquery": "3.5.13",
@@ -3588,21 +3602,21 @@
       "dev": true
     },
     "node_modules/@types/triple-beam": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.2.tgz",
-      "integrity": "sha512-txGIh+0eDFzKGC25zORnswy+br1Ha7hj5cMVwKIU7+s0U2AxxJru/jZSMU6OC9MJWP6+pc/hc6ZjyZShpsyY2g=="
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.3.tgz",
+      "integrity": "sha512-6tOUG+nVHn0cJbVp25JFayS5UE6+xlbcNF9Lo9mU7U0zk3zeUShZied4YEQZjy1JBF043FSkdXw8YkUJuVtB5g=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.6.0.tgz",
-      "integrity": "sha512-CW9YDGTQnNYMIo5lMeuiIG08p4E0cXrXTbcZ2saT/ETE7dWUrNxlijsQeU04qAAKkILiLzdQz+cGFxCJjaZUmA==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.7.0.tgz",
+      "integrity": "sha512-gUqtknHm0TDs1LhY12K2NA3Rmlmp88jK9Tx8vGZMfHeNMLE3GH2e9TRub+y+SOjuYgtOmok+wt1AyDPZqxbNag==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.6.0",
-        "@typescript-eslint/type-utils": "6.6.0",
-        "@typescript-eslint/utils": "6.6.0",
-        "@typescript-eslint/visitor-keys": "6.6.0",
+        "@typescript-eslint/scope-manager": "6.7.0",
+        "@typescript-eslint/type-utils": "6.7.0",
+        "@typescript-eslint/utils": "6.7.0",
+        "@typescript-eslint/visitor-keys": "6.7.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -3628,15 +3642,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.6.0.tgz",
-      "integrity": "sha512-setq5aJgUwtzGrhW177/i+DMLqBaJbdwGj2CPIVFFLE0NCliy5ujIdLHd2D1ysmlmsjdL2GWW+hR85neEfc12w==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.7.0.tgz",
+      "integrity": "sha512-jZKYwqNpNm5kzPVP5z1JXAuxjtl2uG+5NpaMocFPTNC2EdYIgbXIPImObOkhbONxtFTTdoZstLZefbaK+wXZng==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.6.0",
-        "@typescript-eslint/types": "6.6.0",
-        "@typescript-eslint/typescript-estree": "6.6.0",
-        "@typescript-eslint/visitor-keys": "6.6.0",
+        "@typescript-eslint/scope-manager": "6.7.0",
+        "@typescript-eslint/types": "6.7.0",
+        "@typescript-eslint/typescript-estree": "6.7.0",
+        "@typescript-eslint/visitor-keys": "6.7.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -3656,13 +3670,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.6.0.tgz",
-      "integrity": "sha512-pT08u5W/GT4KjPUmEtc2kSYvrH8x89cVzkA0Sy2aaOUIw6YxOIjA8ilwLr/1fLjOedX1QAuBpG9XggWqIIfERw==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.7.0.tgz",
+      "integrity": "sha512-lAT1Uau20lQyjoLUQ5FUMSX/dS07qux9rYd5FGzKz/Kf8W8ccuvMyldb8hadHdK/qOI7aikvQWqulnEq2nCEYA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.6.0",
-        "@typescript-eslint/visitor-keys": "6.6.0"
+        "@typescript-eslint/types": "6.7.0",
+        "@typescript-eslint/visitor-keys": "6.7.0"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -3673,13 +3687,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.6.0.tgz",
-      "integrity": "sha512-8m16fwAcEnQc69IpeDyokNO+D5spo0w1jepWWY2Q6y5ZKNuj5EhVQXjtVAeDDqvW6Yg7dhclbsz6rTtOvcwpHg==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.7.0.tgz",
+      "integrity": "sha512-f/QabJgDAlpSz3qduCyQT0Fw7hHpmhOzY/Rv6zO3yO+HVIdPfIWhrQoAyG+uZVtWAIS85zAyzgAFfyEr+MgBpg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.6.0",
-        "@typescript-eslint/utils": "6.6.0",
+        "@typescript-eslint/typescript-estree": "6.7.0",
+        "@typescript-eslint/utils": "6.7.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -3700,9 +3714,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.6.0.tgz",
-      "integrity": "sha512-CB6QpJQ6BAHlJXdwUmiaXDBmTqIE2bzGTDLADgvqtHWuhfNP3rAOK7kAgRMAET5rDRr9Utt+qAzRBdu3AhR3sg==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.7.0.tgz",
+      "integrity": "sha512-ihPfvOp7pOcN/ysoj0RpBPOx3HQTJTrIN8UZK+WFd3/iDeFHHqeyYxa4hQk4rMhsz9H9mXpR61IzwlBVGXtl9Q==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -3713,13 +3727,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.6.0.tgz",
-      "integrity": "sha512-hMcTQ6Al8MP2E6JKBAaSxSVw5bDhdmbCEhGW/V8QXkb9oNsFkA4SBuOMYVPxD3jbtQ4R/vSODBsr76R6fP3tbA==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.7.0.tgz",
+      "integrity": "sha512-dPvkXj3n6e9yd/0LfojNU8VMUGHWiLuBZvbM6V6QYD+2qxqInE7J+J/ieY2iGwR9ivf/R/haWGkIj04WVUeiSQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.6.0",
-        "@typescript-eslint/visitor-keys": "6.6.0",
+        "@typescript-eslint/types": "6.7.0",
+        "@typescript-eslint/visitor-keys": "6.7.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -3769,17 +3783,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.6.0.tgz",
-      "integrity": "sha512-mPHFoNa2bPIWWglWYdR0QfY9GN0CfvvXX1Sv6DlSTive3jlMTUy+an67//Gysc+0Me9pjitrq0LJp0nGtLgftw==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.7.0.tgz",
+      "integrity": "sha512-MfCq3cM0vh2slSikQYqK2Gq52gvOhe57vD2RM3V4gQRZYX4rDPnKLu5p6cm89+LJiGlwEXU8hkYxhqqEC/V3qA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.6.0",
-        "@typescript-eslint/types": "6.6.0",
-        "@typescript-eslint/typescript-estree": "6.6.0",
+        "@typescript-eslint/scope-manager": "6.7.0",
+        "@typescript-eslint/types": "6.7.0",
+        "@typescript-eslint/typescript-estree": "6.7.0",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -3794,12 +3808,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.6.0.tgz",
-      "integrity": "sha512-L61uJT26cMOfFQ+lMZKoJNbAEckLe539VhTxiGHrWl5XSKQgA0RTBZJW2HFPy5T0ZvPVSD93QsrTKDkfNwJGyQ==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.7.0.tgz",
+      "integrity": "sha512-/C1RVgKFDmGMcVGeD8HjKv2bd72oI1KxQDeY8uc66gw9R0OK0eMq48cA+jv9/2Ag6cdrsUGySm1yzYmfz0hxwQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.6.0",
+        "@typescript-eslint/types": "6.7.0",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -11641,16 +11655,16 @@
       }
     },
     "node_modules/cds-plugin-ui5": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/cds-plugin-ui5/-/cds-plugin-ui5-0.5.2.tgz",
-      "integrity": "sha512-AGB/Tj6AOodZIr3hNEZWeodSG+SURDm4sziz5EJIvhWUNPFbg1+lcpJ8OLAEluvPIpBKOc1Rh7W28ZNQRhcE+g==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/cds-plugin-ui5/-/cds-plugin-ui5-0.6.8.tgz",
+      "integrity": "sha512-75YiPmZvl8EeZcpFV44VuGT4BL+FFoE52sZlZGVBhldmCw8k65uCgpb0PehtsB3n98dLg9yYFi+JVkqNeTZBxg==",
       "dev": true,
       "dependencies": {
         "@ui5/fs": "^3.0.4",
-        "@ui5/project": "^3.5.0",
+        "@ui5/project": "^3.7.0",
         "@ui5/server": "^3.1.3",
         "js-yaml": "^4.1.0",
-        "node-html-parser": "^6.1.5"
+        "node-html-parser": "^6.1.8"
       },
       "peerDependencies": {
         "@sap/cds": ">=6.8.2",
@@ -12764,16 +12778,16 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.48.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.48.0.tgz",
-      "integrity": "sha512-sb6DLeIuRXxeM1YljSe1KEx9/YYeZFQWcV8Rq9HfigmdDEugjLEVEa1ozDjL6YDjBpQHPJxJzze+alxi4T3OLg==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.49.0.tgz",
+      "integrity": "sha512-jw03ENfm6VJI0jA9U+8H5zfl5b+FvuU3YYvZRdZHOlU2ggJkxrlkJH4HcDrZpj6YwD8kuYqvQM8LyesoazrSOQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
         "@eslint/eslintrc": "^2.1.2",
-        "@eslint/js": "8.48.0",
-        "@humanwhocodes/config-array": "^0.11.10",
+        "@eslint/js": "8.49.0",
+        "@humanwhocodes/config-array": "^0.11.11",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.12.4",
@@ -15974,9 +15988,9 @@
       }
     },
     "node_modules/node-html-parser": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.6.tgz",
-      "integrity": "sha512-C/MGDQ2NjdjzUq41bW9kW00MPZecAe/oo89vZEFLDfWoQVDk/DdML1yuxVVKLDMFIFax2VTq6Vpfzyn7z5yYgQ==",
+      "version": "6.1.9",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.9.tgz",
+      "integrity": "sha512-nQ+MRf0PmRTLcMalVqMsWvceSaBydBCBlnQSL78HVk/E8e0Aazyao4SI9aB67XAAgOgHMsw7q5dJBUPPt9XE3g==",
       "dev": true,
       "dependencies": {
         "css-select": "^5.1.0",
@@ -16324,9 +16338,9 @@
       }
     },
     "node_modules/opossum": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/opossum/-/opossum-8.1.0.tgz",
-      "integrity": "sha512-HEdo+rD3Wxs52KpJrXx0BUHB1L/DxNcuU1ZK2Jk/fFv59swCVsBZahfGvQn+FNyfNs/dE4QCwFz0gFCKAFZcWA==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/opossum/-/opossum-8.1.1.tgz",
+      "integrity": "sha512-h3KnacBq8uc31QTUSxgP2jA6nUbh/cXeqoLL40N8jSNXhvAkhQl5O1GAfRFA2dUSj3EFHIsyhkqUxBq7HQ5gtA==",
       "engines": {
         "node": "^20 || ^18 || ^16"
       }
@@ -18405,17 +18419,18 @@
       "dev": true
     },
     "node_modules/ui5-middleware-cfdestination": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/ui5-middleware-cfdestination/-/ui5-middleware-cfdestination-3.1.4.tgz",
-      "integrity": "sha512-HoA3rqgULR/gh2gBVDHwGMwD57fP21bBo90wen4iyFQMO2O/12R1qjh0uakL/zNBh6DIhoOYuRe1cdyKXUYI9Q==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ui5-middleware-cfdestination/-/ui5-middleware-cfdestination-3.2.0.tgz",
+      "integrity": "sha512-Xg9oRVc3MvynzfUCKwzqc42Tl+FeMf+YjYA7QhagWDvDpTqIQNNZV5VVdZ6pePrA9R3vWk55RKBCFw+k89lYKA==",
       "dev": true,
       "dependencies": {
-        "@sap/approuter": "^14.3.0",
+        "@sap/approuter": "^14.3.1",
         "content-type": "^1.0.5",
         "dotenv": "^16.3.1",
         "http-proxy-middleware": "^2.0.6",
         "mime-types": "^2.1.35",
-        "portfinder": "^1.0.32"
+        "portfinder": "^1.0.32",
+        "ui5-middleware-websocket": "^3.0.0-alpha.1"
       }
     },
     "node_modules/ui5-middleware-index": {
@@ -18436,18 +18451,48 @@
         "yargs": "^17.7.2"
       }
     },
-    "node_modules/ui5-tooling-transpile": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/ui5-tooling-transpile/-/ui5-tooling-transpile-3.2.2.tgz",
-      "integrity": "sha512-s1pb1nM3tLSTpUdsVTjsUbZuvGc5zJu23K0B3hg1gSMyUbJIpyv8inNXOtvDznsGzDg/tyjOOP8XavazGf0JVA==",
+    "node_modules/ui5-middleware-websocket": {
+      "version": "3.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/ui5-middleware-websocket/-/ui5-middleware-websocket-3.0.0-alpha.1.tgz",
+      "integrity": "sha512-kDfX0QOrOx1GwlEAnts4cQiPn3aeQQ9l15WRd2vRAQSukkQtM/AOLhqxQ5IkmJiP8Ugo9UwbZ3Qoj/FwfloIpg==",
       "dev": true,
       "dependencies": {
-        "@babel/core": "^7.22.10",
-        "@babel/preset-env": "^7.22.10",
-        "@babel/preset-typescript": "^7.22.5",
+        "ws": "^8.14.0"
+      }
+    },
+    "node_modules/ui5-middleware-websocket/node_modules/ws": {
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.1.tgz",
+      "integrity": "sha512-4OOseMUq8AzRBI/7SLMUwO+FEDnguetSk7KMb1sHwvF2w2Wv5Hoj0nlifx8vtGsftE/jWHojPy8sMMzYLJ2G/A==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ui5-tooling-transpile": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/ui5-tooling-transpile/-/ui5-tooling-transpile-3.2.3.tgz",
+      "integrity": "sha512-2uxdWd7onkMa0bAHpSWs0Sag8iS/stTo59PxmUol152LH6U0rGZUBnSyr5ckH1RL2OmbqJnVgOOsoXmdLiMerw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.22.15",
+        "@babel/preset-env": "^7.22.15",
+        "@babel/preset-typescript": "^7.22.15",
         "babel-plugin-transform-async-to-promises": "^0.8.18",
         "babel-plugin-transform-remove-console": "^6.9.4",
-        "babel-preset-transform-ui5": "^7.2.4",
+        "babel-preset-transform-ui5": "^7.2.5",
         "browserslist": "^4.21.10",
         "comment-json": "^4.2.3"
       },

--- a/package.json
+++ b/package.json
@@ -6,28 +6,28 @@
   },
   "scripts": {
     "start": "cds-serve",
-    "watch": "cds watch --profile local",
+    "watch": "cds watch --livereload false --profile local",
     "build": "mbt build --mtar build.mtar",
     "deploy": "cf deploy ./mta_archives/build.mtar --version-rule ALL",
     "pretty": "./node_modules/.bin/prettier . --write"
   },
   "dependencies": {
-    "@sap-cloud-sdk/connectivity": "^3.2.0",
-    "@sap-cloud-sdk/http-client": "^3.2.0",
-    "@sap/cds": "^7.0.0",
-    "@sap/cds-odata-v2-adapter-proxy": "^1.7.12",
+    "@sap-cloud-sdk/connectivity": "^3.4.0",
+    "@sap-cloud-sdk/http-client": "^3.4.0",
+    "@sap/cds": "^7.2.0",
+    "@sap/cds-odata-v2-adapter-proxy": "^1.9.21",
     "passport": "^0.6.0"
   },
   "devDependencies": {
-    "@prettier/plugin-xml": "^3.1.1",
+    "@prettier/plugin-xml": "^3.2.0",
     "@sap/eslint-plugin-cds": "^2.6.3",
-    "cds-plugin-ui5": "^0.5.1",
-    "eslint": "^8.23.0",
-    "eslint-config-prettier": "^8.1.0",
-    "eslint-config-standard": "^17.0.0",
+    "cds-plugin-ui5": "^0.5.2",
+    "eslint": "^8.48.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-config-standard": "^17.1.0",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-sonarjs": "^0.19.0",
-    "prettier": "^3.0.0"
+    "eslint-plugin-sonarjs": "^0.21.0",
+    "prettier": "^3.0.3"
   },
   "cds": {
     "requires": {

--- a/package.json
+++ b/package.json
@@ -12,17 +12,17 @@
     "pretty": "./node_modules/.bin/prettier . --write"
   },
   "dependencies": {
-    "@sap-cloud-sdk/connectivity": "^3.4.0",
-    "@sap-cloud-sdk/http-client": "^3.4.0",
+    "@sap-cloud-sdk/connectivity": "^3.5.0",
+    "@sap-cloud-sdk/http-client": "^3.5.0",
     "@sap/cds": "^7.2.0",
     "@sap/cds-odata-v2-adapter-proxy": "^1.9.21",
     "passport": "^0.6.0"
   },
   "devDependencies": {
-    "@prettier/plugin-xml": "^3.2.0",
+    "@prettier/plugin-xml": "^3.2.1",
     "@sap/eslint-plugin-cds": "^2.6.3",
-    "cds-plugin-ui5": "^0.5.2",
-    "eslint": "^8.48.0",
+    "cds-plugin-ui5": "^0.6.8",
+    "eslint": "^8.49.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-config-standard": "^17.1.0",
     "eslint-plugin-node": "^11.1.0",


### PR DESCRIPTION
Lets the UI5 application run inside of CAP with the `cds-plugin-ui5` using the `ui5-middleware-cfdestination`:

- Updated to latest dependency versions (for latest improvements around path handling)
- Adapted the UI5 application to use relative dataSources to ensure the `ci/` path is relative to the UI5 application and covered in this scenario here (this is maybe wrong for usage without the `ui5-middleware-cfdestination` when the dataSource should be loaded from `/ci/`)

The UAA works now properly!